### PR TITLE
Use virtual service URL to request legend icon if available

### DIFF
--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -42,7 +42,12 @@
             scope.getLegendUrl = function(layer) {
               var url = null;
               var server = serverService.getServerById(layer.get('metadata').serverId);
-              url = server.url + '?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=' +
+              if (goog.isDefAndNotNull(server.virtualServiceUrl)) {
+                domain = server.virtualServiceUrl;
+              } else {
+                domain = server.url;
+              }
+              url = domain + '?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=' +
                   layer.get('metadata').name + '&transparent=true&legend_options=fontColor:0xFFFFFF;' +
                   'fontAntiAliasing:true;fontSize:14;fontStyle:bold;';
               return url;


### PR DESCRIPTION
This is a fix for https://github.com/boundlessgeo/exchange/issues/3

The server object's 'url' property is incorrect when the Python Corsa library is being used to proxy requests to GeoServer. Using 'server.virtualServiceUrl' fixes this issue.