### PR TITLE
Enable Remote Service Editing

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -108,6 +108,37 @@ var SERVER_SERVICE_USE_PROXY = true;
       return server;
     };
 
+    this.getServerByUrl = function(url) {
+      var server = null;
+
+      if (url.indexOf('/wms') === -1) {
+        url += '/wms';
+      }
+
+      if (!goog.isDefAndNotNull(url)) {
+        throw ({
+          name: 'serverService',
+          level: 'High',
+          message: 'undefined server name.',
+          toString: function() {
+            return this.name + ': ' + this.message;
+          }
+        });
+      }
+
+      for (var index = 0; index < servers.length; index += 1) {
+        var serverUrl = goog.isDefAndNotNull(servers[index].virtualServiceUrl) ? servers[index].virtualServiceUrl : servers[index].url;
+        console.log(' - ' + serverUrl);
+        if (serverUrl === url) {
+          server = servers[index];
+          break;
+        }
+      }
+
+      //console.log('----[ returning server with name: ', name, ', server: ', server);
+      return server;
+    };
+
     this.getServerByName = function(name) {
       var server = null;
 
@@ -179,6 +210,23 @@ var SERVER_SERVICE_USE_PROXY = true;
       } else {
         serverInfo.isVirtualService = false;
       }
+    };
+
+    this.returnVirtualServiceUrlIfAvailable = function(server) {
+      // favor virtual service url when available
+      var mostSpecificUrl = server.url;
+      var mostSpecificUrlWms = server.url;
+      if (goog.isDefAndNotNull(server.isVirtualService) && server.isVirtualService === true) {
+        mostSpecificUrlWms = server.virtualServiceUrl;
+      }
+      if (goog.isDefAndNotNull(mostSpecificUrlWms)) {
+        var urlIndex = mostSpecificUrlWms.lastIndexOf('/');
+        if (urlIndex !== -1) {
+          mostSpecificUrl = mostSpecificUrlWms.slice(0, urlIndex);
+        }
+      }
+
+      return mostSpecificUrl;
     };
 
     this.changeCredentials = function(server) {
@@ -693,4 +741,3 @@ function addXMLRequestCallback(callback) {
     };
   }
 }
-

--- a/src/common/featuremanager/FeatureManagerService.js
+++ b/src/common/featuremanager/FeatureManagerService.js
@@ -3,6 +3,7 @@
 
   //-- Private Variables
   var service_ = null;
+  var serverService_ = null;
   var mapService_ = null;
   var rootScope_ = null;
   var translate_ = null;
@@ -59,12 +60,13 @@
 
   module.provider('featureManagerService', function() {
 
-    this.$get = function($rootScope, $translate, $q, mapService, $compile, $http, exclusiveModeService, dialogService,
+    this.$get = function($rootScope, $translate, $q, mapService, serverService, $compile, $http, exclusiveModeService, dialogService,
                          historyService, configService) {
       //console.log('---- featureInfoBoxService.get');
       rootScope_ = $rootScope;
       service_ = this;
       mapService_ = mapService;
+      serverService_ = serverService;
       historyService_ = historyService;
       translate_ = $translate;
       httpService_ = $http;
@@ -1103,12 +1105,14 @@
         wfsRequestTypePartial +
         '</wfs:Transaction>';
 
-    var url = selectedLayer_.get('metadata').url + '/wfs/WfsDispatcher';
+    var server = serverService_.getServerByUrl(selectedLayer_.get('metadata').url);
+    var serverUrl = serverService_.returnVirtualServiceUrlIfAvailable(server);
+    var wfsurl = serverUrl + '/wfs/WfsDispatcher';
     var layerName = selectedLayer_.get('metadata').uniqueID;
-    httpService_.post(url, wfsRequestData).success(function(data, status, headers, config) {
-      //console.log('====[ great success. ', data, status, headers, config);
+
+    function _handleFeaturePostSuccess(data) {
       var x2js = new X2JS();
-      var json = x2js.xml_str2json(data);
+      var json = x2js.xml2json(data);
       if (goog.isDefAndNotNull(json.WFS_TransactionResponse) &&
           goog.isDefAndNotNull(json.WFS_TransactionResponse.TransactionResult.Status.SUCCESS)) {
         if (postType === wfsPostTypes_.INSERT) {
@@ -1145,10 +1149,33 @@
         console.log(json);
         deferredResponse.reject(translate_.instant('unknown_error'));
       }
-    }).error(function(data, status, headers, config) {
+    }
+
+    function _buildHeaders(xhr) {
+      if (goog.isDefAndNotNull(server.authentication)) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + server.authentication);
+      } else {
+        return;
+      }
+    }
+
+    function _handleFeaturePostError(data, status, headers, config) {
       console.log('----[ ERROR: wfs-t post failed! ', data, status, headers, config);
       deferredResponse.reject(status);
+    }
+
+    $.ajax({
+      url: wfsurl,
+      beforeSend: _buildHeaders,
+      type: 'POST',
+      dataType: 'xml',
+      contentType: 'text/html',
+      processData: false,
+      data: wfsRequestData,
+      success: _handleFeaturePostSuccess,
+      error: _handleFeaturePostError
     });
+
     return deferredResponse.promise;
   }
 

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -716,17 +716,39 @@
                   '</wfs:Transaction>';
 
               var wfsurl = mostSpecificUrl + '/wfs/WfsDispatcher';
-              httpService_.post(wfsurl, wfsRequestData).success(function(data, status, headers, config) {
+
+              function _buildHeaders(xhr) {
+                if (goog.isDefAndNotNull(server.authentication)) {
+                  xhr.setRequestHeader('Authorization', 'Basic ' + server.authentication);
+                } else {
+                  return;
+                }
+              }
+
+              function _handlePostResponse(data) {
                 var x2js = new X2JS();
-                var json = x2js.xml_str2json(data);
+                var json = x2js.xml2json(data);
                 if (goog.isDefAndNotNull(json.ServiceExceptionReport) &&
                     goog.isDefAndNotNull(json.ServiceExceptionReport.ServiceException) &&
                     json.ServiceExceptionReport.ServiceException.indexOf('read-only') >= 0) {
                 } else {
                   layer.get('metadata').readOnly = false;
                 }
-              }).error(function(data, status, headers, config) {
+              }
+
+              $.ajax({
+                url: wfsurl,
+                beforeSend: _buildHeaders,
+                type: 'POST',
+                dataType: 'xml',
+                contentType: 'text/html',
+                processData: false,
+                data: wfsRequestData,
+                success: _handlePostResponse,
+                error: function() {
+                }
               });
+
             };
             geogigService_.isGeoGig(layer, server, fullConfig).then(function() {
               testReadOnly();


### PR DESCRIPTION
#### Enable Remote Service Editing
Users are unable to edit remote services because basic authentication is not being passed along with MapLoom's XML POST requests. This PR solves this issue by including basic authentication in the requests' headers. 

#### Add Server Service Helpers
Additionally, this PR adds two helper functions to the server service: 
- `returnVirtualServiceUrlIfAvailable`: this code already existed inside a private function in the map service. I added it to the server service's API so that it can be used elsewhere in the app. 
- `getServerByUrl`: this function returns a server object given that server's URL. This function is being used in the current PR in order to access the server object's `authentication` property, but could at some point be useful elsewhere in the app.