### PR TITLE
Replace layer name with layer id in registry cart

### DIFF
--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -19,9 +19,16 @@
             goog.isDefAndNotNull(layer.get('metadata').config)) {
           var conf = layer.get('metadata').config;
           if (conf.source === currentServerId) {
-            if (conf.name === layerName) {
-              show = false;
-              break;
+            if (conf.registry === true) {
+              if (conf.registryConfig.LayerId === layerConfig.LayerId) {
+                show = false;
+                break;
+              }
+            } else {
+              if (conf.name === layerName) {
+                show = false;
+                break;
+              }
             }
           }
         }

--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -35,7 +35,7 @@
             scope.layerConfig = {Title: 'Title'};
             scope.selectedLayer = {};
             scope.cart = [];
-            cartLayerName = [];
+            cartLayerId = [];
             scope.catalogKey = 0;
             scope.pagination = {sizeDocuments: 1, pages: 1};
 
@@ -214,24 +214,25 @@
             };
 
             scope.addToCart = function(layerConfig) {
-              var layerCopi = layerConfig.Name;
-              var configIndex = cartLayerName.indexOf(layerCopi);
-              if (configIndex === -1) {
-                cartLayerName.push(layerCopi);
+              var layerId = layerConfig.LayerId;
+              var idIndex = cartLayerId.indexOf(layerId);
+              if (idIndex === -1) {
+                cartLayerId.push(layerId);
                 scope.cart.push(layerConfig);
               } else {
-                cartLayerName.splice(configIndex, 1);
-                scope.cart.splice(configIndex, 1);
+                cartLayerId.splice(idIndex, 1);
+                scope.cart.splice(idIndex, 1);
               }
             };
 
             scope.isInCart = function(layerConfig) {
-              return cartLayerName.indexOf(layerConfig.Name) !== -1 ? true : false;
+              var idInCart = cartLayerId.indexOf(layerConfig.LayerId) !== -1 ? true : false;
+              return idInCart;
             };
 
             scope.clearCart = function() {
               scope.cart = [];
-              cartLayerName = [];
+              cartLayerId = [];
             };
 
             scope.filterAddedLayers = function(layerConfig) {

--- a/src/common/addlayers/RegistryLayersDirective.spec.js
+++ b/src/common/addlayers/RegistryLayersDirective.spec.js
@@ -281,13 +281,13 @@ describe('registryLayersDirective', function() {
   });
   describe('#isInCart', function() {
     beforeEach(function() {
-      cartLayerName = [1];
+      cartLayerId = [1];
     });
     it('returns true if in cart', function() {
-      expect(compiledElement.scope().isInCart({'Name':1})).toEqual(true);
+      expect(compiledElement.scope().isInCart({'LayerId':1})).toEqual(true);
     });
     it('returns false if not in cart', function() {
-      expect(compiledElement.scope().isInCart({'Name':2})).toEqual(false);
+      expect(compiledElement.scope().isInCart({'LayerId':2})).toEqual(false);
     });
   });
 });

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -628,6 +628,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         Title: layerInfo.LayerTitle,
         LayerDate: layerInfo.LayerDate,
         LayerCategory: layerInfo.LayerCategory,
+        LayerId: layerInfo.LayerId,
         CRS: ['EPSG:4326'],
         detail_url: configService_.configuration.registryUrl + '/layer/' + layerInfo.LayerId,
         thumbnail_url: layerInfo.ThumbnailURL ? (configService_.configuration.registryUrl + layerInfo.ThumbnailURL) : null,


### PR DESCRIPTION
This PR replaces `layerInfo.Name` with `layerInfo.LayerId` in the registry directive. Some layer names are not unique, which results in multiple layers being selected based on a single click in the registry cart. However, all layer IDs are unique, so basing the cart selection on this attribute avoids such a conflict. Unit tests have also been updated to account for this change.