### PR TITLE
Use GET request for registry results

### DIFF
--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -90,7 +90,8 @@
         ],
         elasticLayerConfig: {
           id: 0,
-          layersConfig: []
+          layersConfig: [],
+          authentication: 'YWRtaW46ZXhjaGFuZ2U='
         },
         currentLanguage: 'en',
         username: 'anonymous',

--- a/src/common/layers/partials/layers.tpl.html
+++ b/src/common/layers/partials/layers.tpl.html
@@ -43,12 +43,12 @@
               <div class="loom-loading" spinner-radius="16" spinner-hidden="!isLoadingTable(layer)"></div>
               <i class="glyphicon glyphicon-list"></i>
             </a>
-            <a type="button" ng-click="showHeatmap(layer)" ng-show="layer.get('metadata').editable == true"
+            <!--a type="button" ng-click="showHeatmap(layer)" ng-show="layer.get('metadata').editable == true"
                class="btn btn-sm btn-default" tooltip-append-to-body="true"
                tooltip-placement="top" tooltip="{{'show_heatmap' | translate}}">
               <div class="loom-loading" spinner-radius="16" spinner-hidden="!isLoadingHeatmap(layer)"></div>
               <i class="glyphicon glyphicon-fire"></i>
-            </a>
+            </a-->
             <a type="button" ng-show="isGeogig(layer)" ng-click="showHistory(layer)"
                class="btn btn-sm btn-default" tooltip-append-to-body="true"
                tooltip-placement="top" tooltip="{{'show_history' | translate}}">

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1411,7 +1411,7 @@
         heatmapLayerTitle = meta.title;
       }
 
-      var source = new ol.source.ServerVector({
+      var source = new ol.source.Vector({
         format: new ol.format.GeoJSON(),
         loader: function(extent, resolution, projection) {
           tableViewService_.getFeaturesWfs(layer, filters, extent).then(function(response) {
@@ -1420,7 +1420,7 @@
             dialogService_.open(translate_.instant('error'), translate_.instant('error'));
           });
         },
-        strategy: ol.loadingstrategy.createTile(new ol.tilegrid.XYZ({
+        strategy: ol.loadingstrategy.tile(new ol.source.XYZ({
           maxZoom: 19
         })),
         projection: 'EPSG:3857'

--- a/src/index.html
+++ b/src/index.html
@@ -30,9 +30,10 @@
 <% if (!(typeof django === 'undefined') && (django)) { %>
     {% get_current_language as language%}
 <script type="text/javascript">
-    var catalogList = JSON.parse("{{ CATALOGLIST|safe }}");
-    console.log(catalogList);
-
+    var catalogList = JSON.parse("{{ CATALOGLIST|safe }}".replace(/'/g, '"'));
+    var registryEnabled = function(){
+      return "{{ REGISTRY }}".toLowerCase() === "true" || true ? true : false;
+    };
     config =  {
         authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
         username: {% if user.is_authenticated %} "{{ user.username }}" {% else %} undefined {% endif %},
@@ -63,7 +64,7 @@
         localCSWBaseUrl: "{{ CATALOGUE_BASE_URL }}",
         csrfToken: "{{ csrf_token }}",
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
-        registryEnabled: "{{ REGISTRY }}".toLowerCase(),
+        registryEnabled: registryEnabled(),
         registryUrl: "{{ REGISTRYURL }}",
         catalogList: catalogList
     };


### PR DESCRIPTION
This PR:
- Adds logic to assemble a REST query to retrieve registry layers rather than using a POST request, as this method is causing problems in Exchange. 
- Replaces some unsupported OL methods currently being used for Heatmap generation. The heatmap functionality is still not fixed.

