### PR TITLE
Fix pagination display on registry modal

### DIFF
--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -139,8 +139,11 @@
             };
 
             scope.$on('totalOfDocs', function(event, totalDocsCount) {
+              console.log(scope.filterOptions); //!DJA xxx2
               scope.pagination.sizeDocuments = totalDocsCount;
               scope.pagination.showdocs = scope.pagination.sizeDocuments < 10 ? scope.pagination.sizeDocuments : scope.filterOptions.size;
+              scope.pagination.docsSoFar = goog.isDefAndNotNull(scope.filterOptions.from) ? scope.filterOptions.from + 10 : scope.filterOptions.size;
+              scope.pagination.docsSoFar = scope.pagination.docsSoFar > totalDocsCount ? totalDocsCount : scope.pagination.docsSoFar;
               scope.pagination.currentPage = scope.pagination.showdocs === 0 ? 0 : (scope.filterOptions.from / scope.pagination.showdocs) + 1;
               scope.pagination.pages = Math.ceil(scope.pagination.sizeDocuments / scope.filterOptions.size);
             });

--- a/src/common/addlayers/partials/registryLayers.tpl.html
+++ b/src/common/addlayers/partials/registryLayers.tpl.html
@@ -24,7 +24,7 @@
                       <button type="button" ng-disabled="!hasPrevious()" ng-click="previousPage();" class="btn btn-default">Previous</button>
                       <button type="button" ng-disabled="!hasNext()" ng-click="nextPage();" class="btn btn-default">Next</button>
                       <span class="text-muted">
-                        Showing {{pagination.showdocs}} of {{pagination.sizeDocuments}} - Page {{pagination.currentPage}} / {{pagination.pages}}
+                        Showing {{pagination.docsSoFar}} of {{pagination.sizeDocuments}} - Page {{pagination.currentPage}} / {{pagination.pages}}
                       </span>
                     </div>
                   </div>

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -90,8 +90,7 @@
         ],
         elasticLayerConfig: {
           id: 0,
-          layersConfig: [],
-          authentication: 'YWRtaW46ZXhjaGFuZ2U='
+          layersConfig: []
         },
         currentLanguage: 'en',
         username: 'anonymous',


### PR DESCRIPTION
This PR fixes the pagination display on the registry modal so that results appear as `10/23`, `20/23`,  `23/23`; rather than `10/23`, `10/23`, `10/23`.
