### PR TITLE
Replace ng-repeat with ng-options in catalog dropdown

### DIFF
--- a/src/common/addlayers/partials/addlayersfilter.tpl.html
+++ b/src/common/addlayers/partials/addlayersfilter.tpl.html
@@ -7,9 +7,10 @@
               ng-model="filterOptions.text" type="text" class="form-control search-input">
           </div>
           <div class="form-group col-md-6 col-xs-6">
-            <select class="form-control search-input select-search" ng-model="catalogKey" ng-change="searchHyper()">
-              <option ng-repeat="(catalogKey, catalog) in serverService.getCatalogList()" value="{{catalogKey}}">{{catalog.name}}</option>
-            </select>
+            <!--select class="form-control search-input select-search" ng-model="catalogKey" ng-change="searchHyper()">
+              <option ng-repeat="(catalogKey, catalog) in serverService.getCatalogList()" value="{{catalogKey}}">{{catalog.name}}</option-->
+            <select class="form-control search-input select-search" value="{{catalogKey}}" ng-change="searchHyper()" ng-model="initc" ng-init="initc = serverService.getCatalogList()[0] || catalogKey" ng-options="catalog.name for (catalogKey, catalog) in serverService.getCatalogList()">
+            <select>
           </div>
         </div>
         <div class="row range-search">

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -104,10 +104,10 @@
         fileserviceUrlTemplate: '/api/fileservice/view/{}',
         fileserviceUploadUrl: '/api/fileservice/',
         registryEnabled: true,
-        registryUrl: 'http://52.38.116.143',
+        registryUrl: 'http://exchange-dev.boundlessps.com/registry',
         catalogList: [
-          {name: 'hypersearch catalog 1', url: 'http://geoshape.geointservices.io/search/hypermap/'},
-          {name: 'hypersearch catalog 2', url: 'http://geoshape.geointservices.io/search/hypermap/'}
+          {name: 'hypersearch catalog 1', url: 'http://exchange-dev.boundlessps.com/hypermap/'},
+          {name: 'hypersearch catalog 2', url: 'http://exchange-dev.boundlessps.com/hypermap/'}
         ]
       };
 


### PR DESCRIPTION
Ng-repeat wasnt populating the dropdown menu of the registry modal in some sessions. Also replacing default registry endpoints in the config service because the current registryUrl is down.
