### PR TITLE
Correctly record name for registry layers

### DIFF
--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -52,6 +52,7 @@
         };
 
         if (layerConfig['registry']) {
+          minimalConfig['name'] = layerConfig.Title;
           minimalConfig['registryConfig'] = layerConfig;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes recording titles of registry layers rather than id numbers.

### Screenshot

![registryfix](https://cloud.githubusercontent.com/assets/8084860/17419236/61ab5cb2-5a51-11e6-9cbd-884a42227803.png)

### Related Issue

[[NODE-265]](https://issues.boundlessgeo.com:8443/browse/NODE-265)
