### PR TITLE
Configuring Maploom to work with a search API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,10 @@ COPY package.json /usr/src/app/
 COPY bower.json /usr/src/app/
 COPY bower-local /usr/src/app/bower-local
 
+COPY . /usr/src/app
+
 RUN npm install
 RUN bower install
-
-# Bundle app source
-COPY . /usr/src/app
 
 RUN grunt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY . /usr/src/app
 RUN bower install
 RUN grunt
 
-EXPOSE 9000
+EXPOSE 3000
 
 CMD [ "grunt", "serve" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ RUN npm install -g grunt-cli karma bower
 RUN echo '{ "allow_root": true }' > /root/.bowerrc
 
 COPY package.json /usr/src/app/
+COPY bower.json /usr/src/app/
+COPY bower-local /usr/src/app/bower-local
+
 RUN npm install
+RUN bower install
 
 # Bundle app source
 COPY . /usr/src/app
 
-RUN bower install
 RUN grunt
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:argon
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+RUN npm install grunt-cli karma bower
+
+# Bundle app source
+COPY . /usr/src/app
+
+RUN npm install
+RUN bower install
+RUN grunt
+
+EXPOSE 9000
+
+CMD [ "grunt", "serve" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM node:argon
+FROM node:slim
 
 # Create app directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install app dependencies
+RUN npm install -g grunt-cli karma bower
+RUN echo '{ "allow_root": true }' > /root/.bowerrc
+
 COPY package.json /usr/src/app/
-RUN npm install grunt-cli karma bower
+RUN npm install
 
 # Bundle app source
 COPY . /usr/src/app
 
-RUN npm install
 RUN bower install
 RUN grunt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:argon
 
 # Create app directory
 RUN mkdir -p /usr/src/app

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -571,7 +571,7 @@ module.exports = function ( grunt ) {
    */
   grunt.renameTask( 'watch', 'delta' );
   grunt.registerTask( 'watch', [ 'build', 'delta' ] );
-  grunt.registerTask('serve', [ 'watch', 'connect:server' ]);
+  grunt.registerTask('serve', [ 'connect:server', 'watch' ]);
   grunt.registerTask('test', ['karma:unit']);
 
   /**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,18 @@ module.exports = function ( grunt ) {
         ' */\n'
     },
 
+    /**
+     * For development
+     */
+    connect: {
+      server: {
+        options: {
+          base: 'app',
+          keepalive: true
+        }
+      }
+    },
+
     gjslint: {
       options: {
         flags: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function ( grunt ) {
     connect: {
       server: {
         options: {
-          port: 9001,
+          port: 3000,
           base: 'build'
         }
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,18 +63,6 @@ module.exports = function ( grunt ) {
         ' */\n'
     },
 
-    /**
-     * For development
-     */
-    connect: {
-      server: {
-        options: {
-          base: 'app',
-          keepalive: true
-        }
-      }
-    },
-
     gjslint: {
       options: {
         flags: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function ( grunt ) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-conventional-changelog');
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-recess');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,18 @@ module.exports = function ( grunt ) {
     pkg: grunt.file.readJSON("package.json"),
 
     /**
+     * Connect server for development
+     */
+    connect: {
+      server: {
+        options: {
+          port: 9001,
+          base: 'build'
+        }
+      }
+    },
+
+    /**
      * The banner is the comment that is placed at the top of our compiled
      * source files. It is first processed as a Grunt template, where the `<%=`
      * pairs are evaluated based on this very configuration object.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -571,7 +571,7 @@ module.exports = function ( grunt ) {
    */
   grunt.renameTask( 'watch', 'delta' );
   grunt.registerTask( 'watch', [ 'build', 'delta' ] );
-  grunt.registerTask('serve', [ 'connect:server', 'watch' ]);
+  grunt.registerTask('serve', [ 'watch', 'connect:server' ]);
   grunt.registerTask('test', ['karma:unit']);
 
   /**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+up:
+	# bring up the services
+	docker-compose up -d
+
+build:
+	docker-compose build
+
+sync:
+	# set up the database tables
+	docker-compose run django python manage.py migrate --noinput
+	# load the default catalog (hypermap)
+	docker-compose run django python manage.py loaddata hypermap/aggregator/fixtures/catalog_default.json
+	# load a superuser admin / admin
+	docker-compose run django python manage.py loaddata hypermap/aggregator/fixtures/user.json
+
+wait:
+	sleep 5
+
+logs:
+	docker-compose logs --follow
+
+down:
+	docker-compose down
+
+test:
+	docker-compose run django python manage.py test hypermap.aggregator --settings=hypermap.settings.test --failfast
+
+reset: down up wait sync
+
+hardreset: build reset

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ The recommended way to develop maploom is to:
 - you can now go to http://geoshape_vm_server_ip/maps/new or http://geoshape_vm_server_ip/layers to create a map from a layer. Changes on your host machine will cause `grunt watch` to rebuild MapLoom, and the symbolic links created by `geoshape-config maploom_dev` will make the newly buit maploom immediately available to Geonode in your VM.
 
 Note that linter used by `grunt watch` is very paticular about the js programing style and guildlines. Be sure to fix all compile issues.
+

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "MapLoom",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "devDependencies": {},
   "dependencies": {
     "bootstrap": "3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "MapLoom",
-  "version": "1.5.1",
+  "version": "1.5.6",
   "devDependencies": {},
   "dependencies": {
     "bootstrap": "3.0.0",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+
+  maploom:
+    build: .
+    volumes:
+      - './src:/usr/src/app/src'
+      - 'Gruntfile.js:/usr/src/app/Gruntifle.js'
+    ports:
+      - "3000:3000"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,9 +1,0 @@
-version: '2'
-services:
-
-  maploom:
-    build: .
-    volumes:
-      - './src:/usr/src/app/src'
-    ports:
-      - "3000:3000"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,5 @@ services:
     build: .
     volumes:
       - './src:/usr/src/app/src'
-      - 'Gruntfile.js:/usr/src/app/Gruntifle.js'
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  ui:
+  maploom:
     build: .
     volumes:
       - './src:/usr/src/app/src'
@@ -46,6 +46,6 @@ services:
     image: terranodo/nginx:3k8k
     links:
       - django
-      - ui
+      - maploom
     ports:
       - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,4 @@ version: '2'
 services:
 
   maploom:
-    build: .
-    volumes:
-      - './src:/usr/src/app/src'
-    ports:
-      - "3000:3000"
+    image: terranodo/maploom

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   maploom:
     build: .
-    volumes:
-      - '.:/usr/src/app'
+#    volumes:
+#      - '.:/usr/src/app'
     ports:
       - "9000:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,51 @@
 version: '2'
 services:
 
-  maploom:
-    image: terranodo/maploom
+  ui:
+    build: .
+    volumes:
+      - './src:/usr/src/app/src'
+    ports:
+      - "3000:3000"
+
+  postgres:
+    image: postgres
+
+  elasticsearch:
+   image: elasticsearch
+
+  rabbitmq:
+     image: rabbitmq
+
+  django:
+    image: terranodo/registry
+    links:
+      - postgres
+      - elasticsearch
+      - rabbitmq
+    environment:
+      - REGISTRY_SEARCH_URL=elasticsearch+http://elasticsearch:9200/
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
+      - ALLOWED_HOSTS=['django',]
+  celery:
+    image: terranodo/registry
+    links:
+      - rabbitmq
+      - postgres
+      - elasticsearch
+    command: celery worker --app=hypermap.celeryapp:app -B -l INFO
+    environment:
+      - REGISTRY_SEARCH_URL=elasticsearch+http://elasticsearch:9200/
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
+      - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
+      - ALLOWED_HOSTS=['django',]
+      - C_FORCE_ROOT=1
+
+  nginx:
+    image: terranodo/nginx:3k8k
+    links:
+      - django
+      - ui
+    ports:
+      - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+
+  maploom:
+    build: .
+    volumes:
+      - '.:/usr/src/app'
+    ports:
+      - "9000:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   maploom:
     build: .
-#    volumes:
-#      - '.:/usr/src/app'
+    volumes:
+      - './src:/usr/src/app/src'
     ports:
-      - "9000:9000"
+      - "3000:3000"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-uglify": "~0.2.0",
@@ -37,10 +38,10 @@
     "grunt-ngmin": "0.0.2",
     "grunt-recess": "~0.3.0",
     "jasmine": "^2.4.1",
+    "karma": "^0.13.22",
     "karma-coverage": "^1.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.0",
-    "karma": "^0.13.22",
     "karma-spec-reporter": "~0.0.24",
     "phantomjs-prebuilt": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Prominent Edge",
   "name": "MapLoom",
-  "version": "1.5.1",
+  "version": "1.5.6",
   "homepage": "http://www.prominentedge.com",
   "licenses": {
     "type": "BSD",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Prominent Edge",
   "name": "MapLoom",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "homepage": "http://www.prominentedge.com",
   "licenses": {
     "type": "BSD",

--- a/src/common/addlayers/AddLayersFilterDirective.js
+++ b/src/common/addlayers/AddLayersFilterDirective.js
@@ -11,8 +11,9 @@
         var sliderValues = scope.sliderValues.slice();
         var changeSliderValues = false;
         var histogram = {};
+        var minIndex = 11;
 
-        scope.minValue = scope.sliderValues[10];
+        scope.minValue = scope.sliderValues[minIndex];
         scope.maxValue = scope.sliderValues[scope.sliderValues.length - 2];
 
         scope.sliderValues.getValue = function(key) {
@@ -21,10 +22,10 @@
 
         scope.defaultSliderValue = function() {
           return {
-            minValue: 10,
+            minValue: minIndex,
             maxValue: sliderValues.length - 2,
             options: {
-              floor: 10,
+              floor: minIndex,
               ceil: sliderValues.length - 2,
               step: 1,
               noSwitching: true, hideLimitLabels: true,

--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -20,7 +20,7 @@
           var conf = layer.get('metadata').config;
           if (conf.source === currentServerId) {
             if (conf.registry === true) {
-              if (conf.registryConfig.LayerId === layerConfig.LayerId) {
+              if (conf.registryConfig.layerId === layerConfig.layerId) {
                 show = false;
                 break;
               }

--- a/src/common/addlayers/RegistryLayersDirective.js
+++ b/src/common/addlayers/RegistryLayersDirective.js
@@ -109,6 +109,7 @@
               if (scope.pagination.currentPage > 0) {
                 return scope.pagination.pages > scope.pagination.currentPage;
               }
+              return false;
             };
             scope.hasPrevious = function() {
               return scope.filterOptions.docsPage > 1;
@@ -178,7 +179,6 @@
             };
 
             var addLayer = function(layerConfig) {
-              console.log(layerConfig);
               layerConfig['registry'] = true;
               LayersService.addLayer(layerConfig, scope.currentServerId, server);
             };

--- a/src/common/addlayers/RegistryLayersDirective.spec.js
+++ b/src/common/addlayers/RegistryLayersDirective.spec.js
@@ -209,12 +209,12 @@ describe('registryLayersDirective', function() {
   describe('#addLayers', function() {
     var layerConfig, minimalConfig, addLayerSpy, zoomToExtentForProjectionSpy, server;
     beforeEach(function() {
-      layerConfig = { add: true, Name: 'Test', extent: [], CRS: ['EPSG:4326'] };
+      layerConfig = { add: true, Name: 'Test', Title: 'TestTitle', extent: [], CRS: ['EPSG:4326'] };
       server = angular.copy(serverService.getRegistryLayerConfig());
       compiledElement.scope().cart = [layerConfig];
       scope.$digest();
       minimalConfig = { source: 0,
-                        name: layerConfig.Name,
+                        name: layerConfig.Title,
                         registry: true,
                         registryConfig: layerConfig
                       };
@@ -284,10 +284,10 @@ describe('registryLayersDirective', function() {
       cartLayerId = [1];
     });
     it('returns true if in cart', function() {
-      expect(compiledElement.scope().isInCart({'LayerId':1})).toEqual(true);
+      expect(compiledElement.scope().isInCart({'layerId':1})).toEqual(true);
     });
     it('returns false if not in cart', function() {
-      expect(compiledElement.scope().isInCart({'LayerId':2})).toEqual(false);
+      expect(compiledElement.scope().isInCart({'layerId':2})).toEqual(false);
     });
   });
 });

--- a/src/common/addlayers/RegistryLayersDirective.spec.js
+++ b/src/common/addlayers/RegistryLayersDirective.spec.js
@@ -84,17 +84,17 @@ describe('registryLayersDirective', function() {
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 10,
+          docsPage: 2,
           size: 10
         }));
       });
       it('next page if from is set', function() {
-        compiledElement.scope().filterOptions.from = 10;
+        compiledElement.scope().filterOptions.docsPage = 2;
         compiledElement.scope().nextPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 20,
+          docsPage: 3,
           size: 10
         }));
       });
@@ -105,51 +105,53 @@ describe('registryLayersDirective', function() {
     });
     describe('#hasNext', function() {
       it('returns true if has next', function() {
-        spyOn(compiledElement.scope(), 'getResults').and.returnValue([1,1,1,1,1,1,1,1,1,1]);
+        compiledElement.scope().pagination.pages = 2;
+        compiledElement.scope().pagination.currentPage = 1;
         expect(compiledElement.scope().hasNext()).toEqual(true);
       });
       it('returns false if result size is less than the search size', function() {
-        spyOn(compiledElement.scope(), 'getResults').and.returnValue([1]);
+        compiledElement.scope().pagination.pages = 1;
+        compiledElement.scope().pagination.currentPage = 1;
         expect(compiledElement.scope().hasNext()).toEqual(false);
       });
     });
     describe('#hasPrevious', function() {
       it('returns true if has previous', function() {
-        compiledElement.scope().filterOptions.from = 10;
+        compiledElement.scope().filterOptions.docsPage = 2;
         expect(compiledElement.scope().hasPrevious()).toEqual(true);
       });
       it('returns false if result is first page', function() {
-        compiledElement.scope().filterOptions.from = null;
+        compiledElement.scope().filterOptions.docsPage = 1;
         expect(compiledElement.scope().hasPrevious()).toEqual(false);
       });
     });
     describe('#previous page', function() {
-      it('sets from', function() {
+      it('sets docsPage', function() {
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: null,
+          docsPage: 1,
           size: 10
         }));
       });
       it('previous page if from is set', function() {
-        compiledElement.scope().filterOptions.from = 20;
+        compiledElement.scope().filterOptions.docsPage = 20;
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 10,
+          docsPage: 19,
           size: 10
         }));
       });
-      it('previous is first page set to null', function() {
-        compiledElement.scope().filterOptions.from = 10;
+      it('previous is first page set to 1', function() {
+        compiledElement.scope().filterOptions.docsPage = 2;
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: null,
+          docsPage: 1,
           size: 10
         }));
       });
@@ -256,8 +258,7 @@ describe('registryLayersDirective', function() {
     describe('with results', function() {
       var layerConfig = { Title: 'Test', add: true, extent: [], CRS: 'EPSG:4326' };
       beforeEach(function() {
-        compiledElement.scope().currentServer = angular.copy(serverService.getRegistryLayerConfig());
-        compiledElement.scope().currentServer.layersConfig.push(layerConfig);
+        spyOn(compiledElement.scope(), 'getResults').and.returnValue([layerConfig]);
         scope.$digest();
       });
       it('click on a result adds it to cart', function() {

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -710,8 +710,8 @@ var SERVER_SERVICE_USE_PROXY = true;
 
     this.reformatLayerHyperConfigs = function(elasticResponse, serverUrl) {
       rootScope_.$broadcast('totalOfDocs', elasticResponse['a.matchDocs']);
-      if (elasticResponse.aggregations) {
-        rootScope_.$broadcast('dateRangeHistogram', elasticResponse.aggregations.range);
+      if (elasticResponse['a.time']) {
+        rootScope_.$broadcast('dateRangeHistogram', elasticResponse['a.time']);
       }
       return createHyperSearchLayerObjects(elasticResponse['d.docs'], serverUrl);
     };
@@ -734,6 +734,14 @@ var SERVER_SERVICE_USE_PROXY = true;
       }
       if (goog.isDefAndNotNull(filter_options.minYear) && goog.isDefAndNotNull(filter_options.maxYear)) {
         url = url + '&q_time=' + encodeURIComponent('[' + filter_options.minYear + '-01-01 TO ' + filter_options.maxYear + '-01-01T00:00:00]');
+      }
+
+      if (goog.isDefAndNotNull(filter_options.mapPreviewCoordinatesBbox)) {
+        url = url + '&q_geo=' + encodeURIComponent(filter_options.mapPreviewCoordinatesBbox);
+      }
+
+      if (filter_options.histogramFlag === true) {
+        url = url + '&a_time_limit=1&a_time_gap=P1Y';
       }
 
       //`size` & `from` should be outside of the query, either at the begining or the end

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -618,11 +618,11 @@ var SERVER_SERVICE_USE_PROXY = true;
       return [layerInfo.min_x, layerInfo.min_y, layerInfo.max_x, layerInfo.max_y];
     };
 
-    var createHyperSearchLayerObject = function(layerInfo, serverUrl) {
+    var createHyperSearchLayerObject = function(layerInfo) {
       return {
         add: true,
         abstract: layerInfo.abstract,
-        name: layerInfo.domain_name,
+        name: layerInfo.name,
         title: layerInfo.title,
         layerDate: layerInfo.layer_date,
         layerCategory: Array.isArray(layerInfo.layer_category) ? layerInfo.layer_category.join(', ') : null,
@@ -649,14 +649,14 @@ var SERVER_SERVICE_USE_PROXY = true;
       return finalConfigs;
     };
 
-    var createHyperSearchLayerObjects = function(layerObjects, serverUrl) {
+    var createHyperSearchLayerObjects = function(layerObjects) {
       var finalConfigs = [];
       layerObjects = Array.isArray(layerObjects) ? layerObjects : [];
 
       //TODO: Update with handling multiple projections per layer if needed.
       for (var iLayer = 0; iLayer < layerObjects.length; iLayer += 1) {
         var layerInfo = layerObjects[iLayer];
-        var configTemplate = createHyperSearchLayerObject(layerInfo, serverUrl);
+        var configTemplate = createHyperSearchLayerObject(layerInfo);
 
         finalConfigs.push(configTemplate);
       }
@@ -685,8 +685,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       return '/geoserver/wms';
     };
 
-    var addSearchResults = function(searchUrl, body, server, layerConfigCallback) {
-      body = body || {};
+    var addSearchResults = function(searchUrl, server, layerConfigCallback) {
       var layers_loaded = false;
       server.layersConfig = [];
       server.populatingLayersConfig = true;
@@ -713,7 +712,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       if (elasticResponse['a.time']) {
         rootScope_.$broadcast('dateRangeHistogram', elasticResponse['a.time']);
       }
-      return createHyperSearchLayerObjects(elasticResponse['d.docs'], serverUrl);
+      return createHyperSearchLayerObjects(elasticResponse['d.docs']);
     };
 
     this.reformatLayerConfigs = function(elasticResponse, serverUrl) {
@@ -736,7 +735,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         url = url + '&q_time=' + encodeURIComponent('[' + filter_options.minYear + '-01-01 TO ' + filter_options.maxYear + '-01-01T00:00:00]');
       }
 
-      if (goog.isDefAndNotNull(filter_options.mapPreviewCoordinatesBbox)) {
+      if (angular.isArray(filter_options.mapPreviewCoordinatesBbox) && filter_options.mapPreviewCoordinatesBbox.length) {
         url = url + '&q_geo=' + encodeURIComponent(filter_options.mapPreviewCoordinatesBbox);
       }
 
@@ -766,7 +765,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       if (!isNaN(catalogKey) && catalogList.length >= catalogKey + 1) {
         return catalogKey;
       }else {
-        return null;
+        return false;
       }
     };
 
@@ -776,7 +775,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       if (filterOptions !== null) {
         searchUrl = service_.applyESFilter(searchUrl, filterOptions);
       }
-      return addSearchResults(searchUrl, {}, server, service_.reformatLayerConfigs);
+      return addSearchResults(searchUrl, server, service_.reformatLayerConfigs);
     };
 
     this.populateLayersConfigInelastic = function(server, deferredResponse) {
@@ -833,7 +832,6 @@ var SERVER_SERVICE_USE_PROXY = true;
 
     this.addSearchResultsForHyper = function(server, filterOptions, catalogKey) {
       var searchUrl;
-      var bodySearch = {};
       catalogKey_ = service_.validateCatalogKey(catalogKey);
       if (catalogKey_ === false) {
         return false;
@@ -846,7 +844,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       if (filterOptions !== null) {
         searchUrl = service_.applyESFilter(searchUrl, filterOptions);
       }
-      return addSearchResults(searchUrl, bodySearch, server, service_.reformatLayerHyperConfigs);
+      return addSearchResults(searchUrl, server, service_.reformatLayerHyperConfigs);
     };
 
     this.addSearchResultsForFavorites = function(server, filterOptions) {
@@ -854,7 +852,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       if (filterOptions !== null) {
         searchUrl = this.applyFavoritesFilter(searchUrl, filterOptions);
       }
-      return addSearchResults(searchUrl, {}, server, service_.reformatConfigForFavorites);
+      return addSearchResults(searchUrl, server, service_.reformatConfigForFavorites);
     };
 
     this.populateLayersConfig = function(server, force) {

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -619,6 +619,7 @@ var SERVER_SERVICE_USE_PROXY = true;
     };
 
     var createHyperSearchLayerObject = function(layerInfo) {
+      console.log(layerInfo);
       return {
         add: true,
         abstract: layerInfo.abstract,
@@ -628,7 +629,8 @@ var SERVER_SERVICE_USE_PROXY = true;
         layerCategory: Array.isArray(layerInfo.layer_category) ? layerInfo.layer_category.join(', ') : null,
         layerId: layerInfo.id,
         CRS: ['EPSG:4326'],
-        detail_url: catalogKey_ !== null ? catalogList[catalogKey_].registryUrl + '/layer/' + layerInfo.id : null,
+        tile_url: layerInfo.tile_url,
+        detail_url: 'http://localhost/' + 'registry/hypermap/' + 'layer' + layerInfo.detail_url.split('layers')[1],
         author: author(layerInfo),
         domain: domain(layerInfo),
         type: 'mapproxy_tms',

--- a/src/common/addlayers/ServerService.spec.js
+++ b/src/common/addlayers/ServerService.spec.js
@@ -344,7 +344,7 @@ describe('addLayers/ServerService', function() {
     });
     describe('server is available and returns results', function() {
       beforeEach(function() {
-        $httpBackend.expect('GET', 'http://geoshape.geointservices.io/search/hypermap/_search?').respond(200, []);
+        $httpBackend.expect('GET', 'http://exchange-dev.boundlessps.com/hypermap/_search?').respond(200, []);
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatLayerHyperConfigs');
@@ -356,7 +356,7 @@ describe('addLayers/ServerService', function() {
         spyOn(serverService, 'reformatLayerHyperConfigs');
         serverService.addSearchResultsForHyper({}, null, 0);
         $httpBackend.flush();
-        expect(serverService.reformatLayerHyperConfigs).toHaveBeenCalledWith([], 'http://geoshape.geointservices.io/geoserver/wms');
+        expect(serverService.reformatLayerHyperConfigs).toHaveBeenCalledWith([], 'http://exchange-dev.boundlessps.com/geoserver/wms');
       });
     });
   });

--- a/src/common/addlayers/ServerService.spec.js
+++ b/src/common/addlayers/ServerService.spec.js
@@ -2,7 +2,7 @@ console.log = function(sdf) {}; ///turn off console logging when the test runs
 describe('addLayers/ServerService', function() {
   var serverService, $httpBackend;
   var configService = {};
-  var filterOptions = { owner: null, text: null, from: null, size: null };
+  var filterOptions = { owner: null, text: null, docsPage: null, size: null };
   beforeEach(module('MapLoom'));
   beforeEach(module('loom_addlayers'));
 
@@ -108,25 +108,22 @@ describe('addLayers/ServerService', function() {
       });
     });
     describe('result has one layer', function() {
-      var layers = { hits: {} };
+      var layers = { 'd.docs': [] };
       beforeEach(function() {
-        layers.hits.hits = [
+        layers['d.docs'] = [
           {
-            _type: 'layer',
-            _id: '61',
-            _source: {
-              title: 'Ocean Beach',
-              abstract: '',
-              id: '60',
-              name: 'geonode:oceanbeach',
-              LayerUrl: '/layers/OceanBeach',
-              DomainName: 'harvard.org',
-              LayerUsername: 'Admin',
-              MaxX: 1,
-              MaxY: 1,
-              MinX: 0,
-              MinY: 0
-            }
+            type: 'Layer',
+            id: '61',
+            title: 'Ocean Beach',
+            abstract: '',
+            name: "12790",
+            domain_name: 'harvard.org',
+            LayerUrl: '/layers/OceanBeach',
+            LayerUsername: 'Admin',
+            max_x: 1,
+            max_y: 1,
+            min_x: 0,
+            min_y: 0
           }
         ];
       });
@@ -135,7 +132,7 @@ describe('addLayers/ServerService', function() {
       });
       it('has a Title', function() {
         expect(serverService.reformatLayerHyperConfigs(layers, '')[0]).toEqual(jasmine.objectContaining({
-          Title: 'Ocean Beach'
+          title: 'Ocean Beach'
         }));
       });
       it('has a Domain', function() {
@@ -197,32 +194,23 @@ describe('addLayers/ServerService', function() {
         var filterOptions = {
           owner: null,
           text: null,
-          from: null,
-          size: null
+          docsPage: 0,
+          size: null,
+          mapPreviewCoordinatesBbox: [],
+          histogramFlag: false
         };
         expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory');
       });
     });
     describe('only text filter', function() {
-      it('returns the url with q', function() {
+      it('returns the url with q_text', function() {
         var filterOptions = {
           owner: null,
           text: 'Ocean',
-          from: null,
+          docsPage: null,
           size: null
         };
-        var body = {
-                     'query': {
-                       'bool': {
-                         'must': [{
-                                   'query_string': {
-                                     'query': 'Ocean'
-                                   }
-                                 }]
-                       }
-                     }
-                   };
-        expect(serverService.applyBodyFilter(filterOptions)).toEqual(body);
+        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&q_text=Ocean');
       });
     });
     describe('only owner filter', function() {
@@ -233,30 +221,30 @@ describe('addLayers/ServerService', function() {
         var filterOptions = {
           owner: true,
           text: null,
-          from: null,
+          docsPage: null,
           size: null
         };
-        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstoryq=owner__username__in=Dijkstra');
+        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&owner__username__in=Dijkstra');
       });
     });
     describe('pagination', function() {
-      it('first page has no from', function() {
+      it('first page has no docsPage', function() {
         var filterOptions = {
           owner: null,
           text: null,
-          from: null,
+          docsPage: null,
           size: 10
         };
-        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&size=10');
+        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&d_docs_limit=10');
       });
-      it('pagination with from', function() {
+      it('pagination with docsPage', function() {
         var filterOptions = {
           owner: null,
           text: null,
-          from: 10,
+          docsPage: 10,
           size: 10
         };
-        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&size=10&from=10');
+        expect(serverService.applyESFilter('mapstory', filterOptions)).toEqual('mapstory&d_docs_limit=10&d_docs_page=10');
       });
     });
   });
@@ -334,7 +322,7 @@ describe('addLayers/ServerService', function() {
   describe('#addSearchResultsForHyper', function() {
     describe('no server', function() {
       it('returns an empty array', function() {
-        expect(serverService.addSearchResultsForHyper('', filterOptions)).toEqual(false);
+        expect(serverService.addSearchResultsForHyper('', filterOptions, 0)).toEqual(false);
       });
     });
     describe('catalogKey is not a number', function() {
@@ -344,19 +332,15 @@ describe('addLayers/ServerService', function() {
     });
     describe('server is available and returns results', function() {
       beforeEach(function() {
-        $httpBackend.expect('GET', 'http://exchange-dev.boundlessps.com/hypermap/_search?').respond(200, []);
+        var searchUrl = configService.configuration.searchApiURL + '?search_engine=' + catalogList[0].searchEngine +
+            '&search_engine_endpoint=' + encodeURIComponent(catalogList[0].url);
+        $httpBackend.expect('GET', searchUrl).respond(200, []);
       });
       it('reformats the Layer configs based on the server data', function() {
         spyOn(serverService, 'reformatLayerHyperConfigs');
         serverService.addSearchResultsForHyper({}, null, 0);
         $httpBackend.flush();
         expect(serverService.reformatLayerHyperConfigs).toHaveBeenCalled();
-      });
-      it('calls reformatLayerConfigs with a geoserver URL', function() {
-        spyOn(serverService, 'reformatLayerHyperConfigs');
-        serverService.addSearchResultsForHyper({}, null, 0);
-        $httpBackend.flush();
-        expect(serverService.reformatLayerHyperConfigs).toHaveBeenCalledWith([], 'http://exchange-dev.boundlessps.com/geoserver/wms');
       });
     });
   });

--- a/src/common/addlayers/partials/addlayersfilter.tpl.html
+++ b/src/common/addlayers/partials/addlayersfilter.tpl.html
@@ -4,7 +4,7 @@
         <div class="row">
           <div class="search-bar col-md-6 col-xs-6">
             <input name="text_search_input_exp" id="text_search_input_exp" placeholder="Search for ..."
-              ng-model="filterOptions.text" type="text" class="form-control search-input">
+              ng-model="filterOptions.text" ng-change="resetDocsPage()" type="text" class="form-control search-input">
           </div>
           <div class="form-group col-md-6 col-xs-6">
             <select class="form-control search-input select-search" ng-model="catalogKey" ng-change="searchHyper()">

--- a/src/common/addlayers/partials/registryLayers.tpl.html
+++ b/src/common/addlayers/partials/registryLayers.tpl.html
@@ -16,7 +16,7 @@
                       </tr>
                       <tr class="result" ng-mouseover="previewLayer(layer);" ng-click="selectRow(layer)" ng-class="{'preview-hover': isInCart(layer)}"
                         ng-repeat="layer in layersConfig = getResults() | filter:filterAddedLayers">
-                        <td class="ellipsis">{{ layer.Title }}</td>
+                        <td class="ellipsis">{{ layer.title }}</td>
                         <td>{{ layer.domain }}</td>
                       </tr>
                     </table>
@@ -46,18 +46,18 @@
                 <div class="row">
                   <div class="col-md-6 filter panel panel-default add-layer panel-abstract" name="layer-information-panel">
                     <div class="alert alert-title alert-warning-mp">
-                      <h3>{{currentLayer.Title}}</h3>
+                      <h3>{{currentLayer.title}}</h3>
                     </div>
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-md-12">
                             <div class="layer-info-left">
-                              <div class="col-md-12">{{currentLayer.LayerDate || 'Date' | date : 'd/MM/y'}}</div>
-                              <div class="col-md-12">{{currentLayer.LayerCategory || 'Category'}}</div>
+                              <div class="col-md-12">{{currentLayer.layerDate || 'Date' | date : 'd/MM/y'}}</div>
+                              <div class="col-md-12">{{currentLayer.layerCategory || 'Category'}}</div>
                             </div>
                           </div>
                           <div class="col-md-12">
-                            <p class="abstract">{{currentLayer.Abstract}}</p>
+                            <p class="abstract">{{currentLayer.abstract}}</p>
                           </div>
                         </div>
                       </div>
@@ -71,7 +71,7 @@
                       <table class="table table-hover list-results">
                         <tr class="result" ng-repeat="layer in cart.slice().reverse()">
                           <td class="remove-button">
-                            <div class="col-md-10 ellipsis">{{layer.Title}}</div>
+                            <div class="col-md-10 ellipsis">{{layer.title}}</div>
                             <span ng-click="addToCart(layer)" class="glyphicon glyphicon-remove pull-right"></span>
                           </td>
                         </tr>

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -104,10 +104,26 @@
         fileserviceUrlTemplate: '/api/fileservice/view/{}',
         fileserviceUploadUrl: '/api/fileservice/',
         registryEnabled: true,
-        registryUrl: 'http://exchange-dev.boundlessps.com/registry',
+        searchApiURL: 'http://52.53.235.149/registry/api/search/',
         catalogList: [
-          {name: 'hypersearch catalog 1', url: 'http://exchange-dev.boundlessps.com/hypermap/'},
-          {name: 'hypersearch catalog 2', url: 'http://exchange-dev.boundlessps.com/hypermap/'}
+          {
+            searchEngine: 'solr',
+            name: 'Solr catalog',
+            url: 'http://54.221.223.91:8983/solr/hypermap/select/',
+            registryUrl: 'http://52.38.116.143'
+          },
+          {
+            searchEngine: 'elasticsearch',
+            name: 'hypersearch catalog 1',
+            url: 'http://52.41.158.6:9200/hypermap/_search',
+            registryUrl: 'http://52.38.116.143'
+          },
+          {
+            searchEngine: 'elasticsearch',
+            name: 'exchange-dev catalog',
+            url: 'http://exchange-dev.boundlessps.com/hypermap/_search/',
+            registryUrl: 'http://exchange-dev.boundlessps.com/registry'
+          }
         ]
       };
 

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -48,7 +48,7 @@
 
     this.$get = function($window, $http, $cookies, $location, $translate) {
       service_ = this;
-
+      var serverLocation = $location.protocol() + '://' + $location.host();
       this.configuration = {
         about: {
           title: $translate.instant('new_map'),
@@ -104,25 +104,17 @@
         fileserviceUrlTemplate: '/api/fileservice/view/{}',
         fileserviceUploadUrl: '/api/fileservice/',
         registryEnabled: true,
-        searchApiURL: 'http://52.53.235.149/registry/api/search/',
+        searchApiURL: serverLocation + '/registry/api/search/hypermap/',
         catalogList: [
-          {
-            searchEngine: 'solr',
-            name: 'Solr catalog',
-            url: 'http://54.221.223.91:8983/solr/hypermap/select/',
-            registryUrl: 'http://52.38.116.143'
-          },
           {
             searchEngine: 'elasticsearch',
             name: 'hypersearch catalog 1',
-            url: 'http://52.41.158.6:9200/hypermap/_search',
-            registryUrl: 'http://52.38.116.143'
+            url: serverLocation + ':9200/'
           },
           {
-            searchEngine: 'elasticsearch',
-            name: 'exchange-dev catalog',
-            url: 'http://exchange-dev.boundlessps.com/hypermap/_search/',
-            registryUrl: 'http://exchange-dev.boundlessps.com/registry'
+            searchEngine: 'solr',
+            name: 'Solr catalog',
+            url: 'http://54.221.223.91:8983/solr/hypermap/select/'
           }
         ]
       };

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -150,6 +150,15 @@
     ]];
   }
 
+  function angleNormalize(angle) {
+    if (angle < -180) {
+      return 360 + angle;
+    }else if (angle > 180) {
+      return -360 + angle;
+    }
+    return angle;
+  }
+
   function createGeoJSONLayerFromCoordinatesWithProjection(coordinates, projection) {
     var geojsonObject = {
       'type': 'Feature',
@@ -219,6 +228,7 @@
 
       this.createGeoJSONLayerFromCoordinatesWithProjection = createGeoJSONLayerFromCoordinatesWithProjection;
       this.createBBoxFromCoordinatesFromProjectionIntoProjection = createBBoxFromCoordinatesFromProjectionIntoProjection;
+      this.angleNormalize = angleNormalize;
 
       $rootScope.$on('conflict_mode', function() {
         editableLayers_ = service_.getLayers(true);

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -636,10 +636,10 @@
       } else {
         if (fullConfig.type && fullConfig.type == 'mapproxy_tms') {
           var layername = '';
-          if (fullConfig.name.split(':').length > 1) {
-            layername = fullConfig.Name.split(':')[1];
+          if (fullConfig.name && fullConfig.name.split(':').length > 1) {
+            layername = fullConfig.name.split(':')[1];
           } else {
-            layername = fullConfig.Name;
+            layername = fullConfig.name;
           }
 
           layer = new ol.layer.Tile({

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -635,20 +635,13 @@
         });
       } else {
         if (fullConfig.type && fullConfig.type == 'mapproxy_tms') {
-          var layername = '';
-          if (fullConfig.name && fullConfig.name.split(':').length > 1) {
-            layername = fullConfig.name.split(':')[1];
-          } else {
-            layername = fullConfig.name;
-          }
-
           layer = new ol.layer.Tile({
             metadata: {
               name: minimalConfig.name,
               url: goog.isDefAndNotNull(mostSpecificUrl) ? mostSpecificUrl : undefined,
               title: fullConfig.Title,
               extent: fullConfig['extent'],
-              abstract: fullConfig.Abstract,
+              abstract: fullConfig.abstract,
               readOnly: false,
               editable: false,
               projection: service_.getCRSCode(fullConfig.CRS),
@@ -659,7 +652,7 @@
             },
             visible: true,
             source: new ol.source.XYZ({
-              url: fullConfig.detail_url + '/map/wmts/' + layername + '/default_grid/{z}/{x}/{y}.png'
+              url: fullConfig.detail_url
             })
           });
         } else if (server.ptype === 'gxp_osmsource') {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -626,7 +626,7 @@
       } else {
         if (fullConfig.type && fullConfig.type == 'mapproxy_tms') {
           var layername = '';
-          if (fullConfig.Name.split(':').length > 1) {
+          if (fullConfig.name.split(':').length > 1) {
             layername = fullConfig.Name.split(':')[1];
           } else {
             layername = fullConfig.Name;


### PR DESCRIPTION
## What does this PR do?
* Integrate Maploom registry with a agnostic search API
* Multi catalog list support 
* Filter search by text, date, spatial
* Histogram bug fixed

### Screenshots:
### Maploom registry Main view
<img width="1440" alt="screen shot 2016-08-24 at 12 59 47" src="https://cloud.githubusercontent.com/assets/7197750/17928416/d168df26-69fa-11e6-9637-5f60067a131f.png">

#### Select a layer, watch the preview and add to map:
![zbkciztqro](https://cloud.githubusercontent.com/assets/7197750/17906534/0cc12eee-6978-11e6-8f63-a6b3e71da48d.gif)

#### Select a catalog to add to the map:
![xktxihhlyn](https://cloud.githubusercontent.com/assets/7197750/17909781/511fbac0-6986-11e6-9c7f-3ce715003342.gif)

#### Text search:
![hiuxr72s9g](https://cloud.githubusercontent.com/assets/7197750/17906623/6fb7f154-6978-11e6-8bf1-45dd9498c623.gif)

#### Select multiple layers at time:
![gbhkcptns5](https://cloud.githubusercontent.com/assets/7197750/17906702/b8980710-6978-11e6-87c9-cc94be81e68b.gif)

#### Geoespacial search:
![yfluybilt9](https://cloud.githubusercontent.com/assets/7197750/17907216/2297d558-697b-11e6-946b-406d209ca2c6.gif)

#### Filter time search:
![pvdntyqcce](https://cloud.githubusercontent.com/assets/7197750/17907248/577ff552-697b-11e6-94ec-e432baa0b71b.gif)

