### PR TITLE
Configuring Maploom to work with search API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "MapLoom",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "devDependencies": {},
   "dependencies": {
     "bootstrap": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Prominent Edge",
   "name": "MapLoom",
-  "version": "1.5.5",
+  "version": "1.5.7",
   "homepage": "http://www.prominentedge.com",
   "licenses": {
     "type": "BSD",

--- a/src/common/addlayers/AddLayersFilterDirective.js
+++ b/src/common/addlayers/AddLayersFilterDirective.js
@@ -8,8 +8,7 @@
       link: function(scope, element) {
 
         var topIndex = -1;
-        var minIndex = 10;
-
+        var minIndex = 11;
         scope.sliderValues = ['5000M BC', '500M BC', '50M BC', '5M BC', '1M BC', '100K BC', '10K BC', '1K BC', '500 BC', '100 BC',
           0, 100, 500, 1000, 1500, 1600, 1700, 1800, 1900, 1910, 1920, 1930, 1940, 1950, 1960, 1970, 1980, 1990, 1991, 1992, 1993,
           1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013,
@@ -65,38 +64,75 @@
           }
         };
 
-        function renderingSvgBars() {
-          if (histogram.buckets) {
-            histogram.barsWidth = $('#bars').width();
-            var barsheight = 40;
-            var rectWidth = histogram.barsWidth / histogram.buckets.length;
-            var svgRect = histogram.buckets.map(function(bar, barKey) {
-              var height = histogram.maxValue === 0 ? 0 : barsheight * bar.doc_count / histogram.maxValue;
-              var y = barsheight - height;
-              var translate = (rectWidth) * barKey;
-              return '<g transform="translate(' + translate + ', 0)">' +
-                     '  <rect width="' + rectWidth + '" height="' + height + '" y="' + y + '" fill="#E4E4E4"></rect>' +
-                     '</g>';
-            });
-            var svgbar = '<svg width="100%" height="' + barsheight + '">' + svgRect.join('') + '</svg>';
-            $('#bars').html(svgbar);
-          }
-        }
-
-        scope.$on('dateRangeHistogram', function(even, histogramData) {
-          histogram = histogramData;
-          histogram.maxValue = Math.max.apply(null, histogram.buckets.map(function(obj) {
-            return obj.doc_count;
-          }));
-          renderingSvgBars();
-        });
-        $(window).resize(renderingSvgBars);
-
         scope.$on('slideEnded', function() {
           if (changeSliderValues) {
             scope.sliderValues = sliderValues.slice();
             changeSliderValues = false;
           }
+        });
+
+        function dateRangeHistogram(counts, sliderValues) {
+          if (!sliderValues || !counts) {
+            return [];
+          }
+          var suma = 0, sliderIndex = 0, histogram = [];
+          for (var i = 0; i < counts.length; i++) {
+            var count = counts[i];
+            var sliderValue = Number(sliderValues[sliderIndex]);
+            suma = suma + count.count;
+            yearCount = Number(count.value.substring(0, 4));
+            yearCountNext = counts[i + 1] === undefined ? null : Number(counts[i + 1].value.substring(0, 4));
+
+            if (yearCount === sliderValue || (yearCount < sliderValue && yearCountNext > sliderValue)) {
+              histogram.push({key: sliderValue, count: suma});
+              suma = 0;
+              sliderIndex++;
+            }
+            while (
+                sliderIndex < sliderValues.length &&
+                (isNaN(sliderValue) || yearCount > sliderValue ||
+                (i + 1 === counts.length && yearCount <= sliderValue))
+            ) {
+              histogram.push({key: sliderValue, count: 0});
+              sliderIndex++;
+              sliderValue = Number(sliderValues[sliderIndex]);
+              i = yearCount === sliderValue ? i - 1 : i;
+            }
+          }
+          return histogram;
+        }
+
+        function makeHistogram(histogram) {
+
+          function renderingSvgBars() {
+            if (histogram.counts) {
+              histogram.barsWidth = $('#bars').width();
+              var barsheight = 40;
+              var rectWidth = histogram.barsWidth / histogram.counts.length;
+              var svgRect = histogram.counts.map(function(bar, barKey) {
+                var height = histogram.maxValue === 0 ? 0 : barsheight * bar.count / histogram.maxValue;
+                var y = barsheight - height;
+                var translate = (rectWidth) * barKey;
+                return '<g transform="translate(' + translate + ', 0)">' +
+                       '  <rect width="' + rectWidth + '" height="' + height + '" y="' + y + '" fill="#E4E4E4"></rect>' +
+                       '</g>';
+              });
+              var svgbar = '<svg width="100%" height="' + barsheight + '">' + svgRect.join('') + '</svg>';
+              $('#bars').html(svgbar);
+            }
+          }
+
+          $(window).resize(renderingSvgBars);
+
+          histogram.maxValue = Math.max.apply(null, histogram.counts.map(function(obj) {
+            return obj.count;
+          }));
+          histogram.counts = dateRangeHistogram(histogram.counts, scope.sliderValues);
+          renderingSvgBars();
+        }
+
+        scope.$on('dateRangeHistogram', function(even, histogramData) {
+          makeHistogram(histogramData);
         });
 
         $('#registry-layer-dialog').on('shown.bs.modal', function() {

--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -20,7 +20,7 @@
           var conf = layer.get('metadata').config;
           if (conf.source === currentServerId) {
             if (conf.registry === true) {
-              if (conf.registryConfig.LayerId === layerConfig.LayerId) {
+              if (conf.registryConfig.layerId === layerConfig.layerId) {
                 show = false;
                 break;
               }
@@ -46,13 +46,13 @@
         //       skipped! note, when MapService.addLayer is called, server's getcapabilities (if applicable)
         //       has already been resolved so you can used that info to append values to the layer.
         var minimalConfig = {
-          name: layerConfig.Name,
+          name: layerConfig.name,
           source: currentServerId,
           registry: layerConfig['registry']
         };
 
         if (layerConfig['registry']) {
-          minimalConfig['name'] = layerConfig.Title;
+          minimalConfig['name'] = layerConfig.title;
           minimalConfig['registryConfig'] = layerConfig;
         }
 
@@ -69,6 +69,5 @@
         }
       }
     };
-
   });
 }());

--- a/src/common/addlayers/RegistryLayersDirective.spec.js
+++ b/src/common/addlayers/RegistryLayersDirective.spec.js
@@ -84,17 +84,17 @@ describe('registryLayersDirective', function() {
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 10,
+          docsPage: 2,
           size: 10
         }));
       });
       it('next page if from is set', function() {
-        compiledElement.scope().filterOptions.from = 10;
+        compiledElement.scope().filterOptions.docsPage = 2;
         compiledElement.scope().nextPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 20,
+          docsPage: 3,
           size: 10
         }));
       });
@@ -105,51 +105,53 @@ describe('registryLayersDirective', function() {
     });
     describe('#hasNext', function() {
       it('returns true if has next', function() {
-        spyOn(compiledElement.scope(), 'getResults').and.returnValue([1,1,1,1,1,1,1,1,1,1]);
+        compiledElement.scope().pagination.pages = 2;
+        compiledElement.scope().pagination.currentPage = 1;
         expect(compiledElement.scope().hasNext()).toEqual(true);
       });
       it('returns false if result size is less than the search size', function() {
-        spyOn(compiledElement.scope(), 'getResults').and.returnValue([1]);
+        compiledElement.scope().pagination.pages = 1;
+        compiledElement.scope().pagination.currentPage = 1;
         expect(compiledElement.scope().hasNext()).toEqual(false);
       });
     });
     describe('#hasPrevious', function() {
       it('returns true if has previous', function() {
-        compiledElement.scope().filterOptions.from = 10;
+        compiledElement.scope().filterOptions.docsPage = 2;
         expect(compiledElement.scope().hasPrevious()).toEqual(true);
       });
       it('returns false if result is first page', function() {
-        compiledElement.scope().filterOptions.from = null;
+        compiledElement.scope().filterOptions.docsPage = 1;
         expect(compiledElement.scope().hasPrevious()).toEqual(false);
       });
     });
     describe('#previous page', function() {
-      it('sets from', function() {
+      it('sets docsPage', function() {
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: null,
+          docsPage: 1,
           size: 10
         }));
       });
       it('previous page if from is set', function() {
-        compiledElement.scope().filterOptions.from = 20;
+        compiledElement.scope().filterOptions.docsPage = 20;
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: 10,
+          docsPage: 19,
           size: 10
         }));
       });
-      it('previous is first page set to null', function() {
-        compiledElement.scope().filterOptions.from = 10;
+      it('previous is first page set to 1', function() {
+        compiledElement.scope().filterOptions.docsPage = 2;
         compiledElement.scope().previousPage();
         expect(compiledElement.scope().filterOptions).toEqual(jasmine.objectContaining({
           text: null,
           owner: null,
-          from: null,
+          docsPage: 1,
           size: 10
         }));
       });
@@ -209,12 +211,12 @@ describe('registryLayersDirective', function() {
   describe('#addLayers', function() {
     var layerConfig, minimalConfig, addLayerSpy, zoomToExtentForProjectionSpy, server;
     beforeEach(function() {
-      layerConfig = { add: true, Name: 'Test', Title: 'TestTitle', extent: [], CRS: ['EPSG:4326'] };
+      layerConfig = { add: true, name: 'Test', title: 'TestTitle', extent: [], CRS: ['EPSG:4326'] };
       server = angular.copy(serverService.getRegistryLayerConfig());
       compiledElement.scope().cart = [layerConfig];
       scope.$digest();
       minimalConfig = { source: 0,
-                        name: layerConfig.Title,
+                        name: layerConfig.title,
                         registry: true,
                         registryConfig: layerConfig
                       };
@@ -256,8 +258,7 @@ describe('registryLayersDirective', function() {
     describe('with results', function() {
       var layerConfig = { Title: 'Test', add: true, extent: [], CRS: 'EPSG:4326' };
       beforeEach(function() {
-        compiledElement.scope().currentServer = angular.copy(serverService.getRegistryLayerConfig());
-        compiledElement.scope().currentServer.layersConfig.push(layerConfig);
+        spyOn(compiledElement.scope(), 'getResults').and.returnValue([layerConfig]);
         scope.$digest();
       });
       it('click on a result adds it to cart', function() {
@@ -284,10 +285,10 @@ describe('registryLayersDirective', function() {
       cartLayerId = [1];
     });
     it('returns true if in cart', function() {
-      expect(compiledElement.scope().isInCart({'LayerId':1})).toEqual(true);
+      expect(compiledElement.scope().isInCart({'layerId':1})).toEqual(true);
     });
     it('returns false if not in cart', function() {
-      expect(compiledElement.scope().isInCart({'LayerId':2})).toEqual(false);
+      expect(compiledElement.scope().isInCart({'layerId':2})).toEqual(false);
     });
   });
 });

--- a/src/common/addlayers/partials/addlayersfilter.tpl.html
+++ b/src/common/addlayers/partials/addlayersfilter.tpl.html
@@ -4,12 +4,11 @@
         <div class="row">
           <div class="search-bar col-md-6 col-xs-6">
             <input name="text_search_input_exp" id="text_search_input_exp" placeholder="Search for ..."
-              ng-model="filterOptions.text" type="text" class="form-control search-input">
+              ng-model="filterOptions.text" ng-change="resetDocsPage()" type="text" class="form-control search-input">
           </div>
           <div class="form-group col-md-6 col-xs-6">
-            <select class="form-control search-input select-search" ng-model="catalogKey" ng-change="searchHyper()">
-              <option ng-repeat="(catalogKey, catalog) in serverService.getCatalogList()" value="{{catalogKey}}">{{catalog.name}}</option>
-            <select>
+              <select class="form-control search-input select-search" ng-model="catalog" ng-change="searchHyper()"
+              ng-options="catalog.name for catalog in catalogList"></select>
           </div>
         </div>
         <div class="row range-search">

--- a/src/common/addlayers/partials/registryLayers.tpl.html
+++ b/src/common/addlayers/partials/registryLayers.tpl.html
@@ -16,7 +16,7 @@
                       </tr>
                       <tr class="result" ng-mouseover="previewLayer(layer);" ng-click="selectRow(layer)" ng-class="{'preview-hover': isInCart(layer)}"
                         ng-repeat="layer in layersConfig = getResults() | filter:filterAddedLayers">
-                        <td class="ellipsis">{{ layer.Title }}</td>
+                        <td class="ellipsis">{{ layer.title }}</td>
                         <td>{{ layer.domain }}</td>
                       </tr>
                     </table>
@@ -46,18 +46,18 @@
                 <div class="row">
                   <div class="col-md-6 filter panel panel-default add-layer panel-abstract" name="layer-information-panel">
                     <div class="alert alert-title alert-warning-mp">
-                      <h3>{{currentLayer.Title}}</h3>
+                      <h3>{{currentLayer.title}}</h3>
                     </div>
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-md-12">
                             <div class="layer-info-left">
-                              <div class="col-md-12">{{currentLayer.LayerDate || 'Date' | date : 'd/MM/y'}}</div>
-                              <div class="col-md-12">{{currentLayer.LayerCategory || 'Category'}}</div>
+                              <div class="col-md-12">{{currentLayer.layerDate || 'Date' | date : 'd/MM/y'}}</div>
+                              <div class="col-md-12">{{currentLayer.layerCategory || 'Category'}}</div>
                             </div>
                           </div>
                           <div class="col-md-12">
-                            <p class="abstract">{{currentLayer.Abstract}}</p>
+                            <p class="abstract">{{currentLayer.abstract}}</p>
                           </div>
                         </div>
                       </div>
@@ -71,7 +71,7 @@
                       <table class="table table-hover list-results">
                         <tr class="result" ng-repeat="layer in cart.slice().reverse()">
                           <td class="remove-button">
-                            <div class="col-md-10 ellipsis">{{layer.Title}}</div>
+                            <div class="col-md-10 ellipsis">{{layer.title}}</div>
                             <span ng-click="addToCart(layer)" class="glyphicon glyphicon-remove pull-right"></span>
                           </td>
                         </tr>

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -48,6 +48,7 @@
 
     this.$get = function($window, $http, $cookies, $location, $translate) {
       service_ = this;
+      var serverLocation = $location.protocol() + '://' + $location.host();
 
       this.configuration = {
         about: {
@@ -104,18 +105,8 @@
         fileserviceUrlTemplate: '/api/fileservice/view/{}',
         fileserviceUploadUrl: '/api/fileservice/',
         registryEnabled: true,
-        catalogList: [
-          {
-            name: 'hypersearch catalog',
-            url: 'http://exchange-dev.boundlessps.com/hypermap/',
-            registryUrl: 'http://exchange-dev.boundlessps.com/registry'
-          },
-          {
-            name: 'hypersearch local catalog',
-            url: 'http://localhost:9200/hypermap/',
-            registryUrl: 'http://localhost/registry/hypermap'
-          }
-        ]
+        serverLocation: serverLocation,
+        searchApiURL: serverLocation + '/registry/api/catalogs/'
       };
 
       if (goog.isDefAndNotNull($window.config)) {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -150,6 +150,15 @@
     ]];
   }
 
+  function angleNormalize(angle) {
+    if (angle < -180) {
+      return 360 + angle;
+    }else if (angle > 180) {
+      return -360 + angle;
+    }
+    return angle;
+  }
+
   function createGeoJSONLayerFromCoordinatesWithProjection(coordinates, projection) {
     var geojsonObject = {
       'type': 'Feature',
@@ -219,6 +228,7 @@
 
       this.createGeoJSONLayerFromCoordinatesWithProjection = createGeoJSONLayerFromCoordinatesWithProjection;
       this.createBBoxFromCoordinatesFromProjectionIntoProjection = createBBoxFromCoordinatesFromProjectionIntoProjection;
+      this.angleNormalize = angleNormalize;
 
       $rootScope.$on('conflict_mode', function() {
         editableLayers_ = service_.getLayers(true);
@@ -534,7 +544,7 @@
     this.createLayerWithFullConfig = function(fullConfig, serverId) {
       var server = serverService_.getServerById(serverId);
       var minimalConfig = {
-        name: fullConfig.Name,
+        name: fullConfig.name,
         source: serverId
       };
       return service_.createLayerFull(minimalConfig, fullConfig, server);
@@ -625,20 +635,13 @@
         });
       } else {
         if (fullConfig.type && fullConfig.type == 'mapproxy_tms') {
-          var layername = '';
-          if (fullConfig.Name.split(':').length > 1) {
-            layername = fullConfig.Name.split(':')[1];
-          } else {
-            layername = fullConfig.Name;
-          }
-
           layer = new ol.layer.Tile({
             metadata: {
               name: minimalConfig.name,
               url: goog.isDefAndNotNull(mostSpecificUrl) ? mostSpecificUrl : undefined,
-              title: fullConfig.Title,
+              title: fullConfig.title,
               extent: fullConfig['extent'],
-              abstract: fullConfig.Abstract,
+              abstract: fullConfig.abstract,
               readOnly: false,
               editable: false,
               projection: service_.getCRSCode(fullConfig.CRS),
@@ -649,7 +652,7 @@
             },
             visible: true,
             source: new ol.source.XYZ({
-              url: fullConfig.detail_url + '/map/wmts/' + layername + '/default_grid/{z}/{x}/{y}.png'
+              url: fullConfig.detail_url
             })
           });
         } else if (server.ptype === 'gxp_osmsource') {


### PR DESCRIPTION
## What does this PR do?
* Integrate Maploom registry with a agnostic search API
* Multi catalog list support 
* Filter search by text, date, spatial
* Histogram bug fixed

### Screenshots:
### Maploom registry Main view
<img width="1440" alt="screen shot 2016-08-24 at 12 59 47" src="https://cloud.githubusercontent.com/assets/7197750/17928416/d168df26-69fa-11e6-9637-5f60067a131f.png">

#### Select a layer, watch the preview and add to map:
![zbkciztqro](https://cloud.githubusercontent.com/assets/7197750/17906534/0cc12eee-6978-11e6-8f63-a6b3e71da48d.gif)

#### Select a catalog to add to the map:
![xktxihhlyn](https://cloud.githubusercontent.com/assets/7197750/17909781/511fbac0-6986-11e6-9c7f-3ce715003342.gif)

#### Text search:
![hiuxr72s9g](https://cloud.githubusercontent.com/assets/7197750/17906623/6fb7f154-6978-11e6-8bf1-45dd9498c623.gif)

#### Select multiple layers at time:
![gbhkcptns5](https://cloud.githubusercontent.com/assets/7197750/17906702/b8980710-6978-11e6-87c9-cc94be81e68b.gif)

#### Geoespacial search:
![yfluybilt9](https://cloud.githubusercontent.com/assets/7197750/17907216/2297d558-697b-11e6-946b-406d209ca2c6.gif)

#### Filter time search:
![pvdntyqcce](https://cloud.githubusercontent.com/assets/7197750/17907248/577ff552-697b-11e6-94ec-e432baa0b71b.gif)

