### PR TITLE
Add Esri World Topo Map Support

### DIFF
--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -46,12 +46,12 @@
         //       skipped! note, when MapService.addLayer is called, server's getcapabilities (if applicable)
         //       has already been resolved so you can used that info to append values to the layer.
         var minimalConfig = {
-          name: layerConfig.name,
+          name: layerConfig.name || layerConfig.Name,
           source: currentServerId,
           registry: layerConfig['registry']
         };
 
-        if (layerConfig['registry']) {
+        if (layerConfig['registry'] === true) {
           minimalConfig['name'] = layerConfig.title;
           minimalConfig['registryConfig'] = layerConfig;
         }

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -473,6 +473,19 @@ var SERVER_SERVICE_USE_PROXY = true;
         service_.getServerByPtype('gxp_bingsource').defaultServer = true;
       }
 
+      if (!goog.isDefAndNotNull(service_.getServerByPtype('gxp_arcrestsource'))) {
+        config = {
+          ptype: 'gxp_arcrestsource',
+          name: 'Esri',
+          defaultServer: true,
+          alwaysAnonymous: true,
+          url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/'
+        };
+        service_.addServer(config);
+      } else {
+        service_.getServerByPtype('gxp_arcrestsource').defaultServer = true;
+      }
+
       if (!goog.isDefAndNotNull(service_.getServerByPtype('gxp_mapquestsource'))) {
         config = {ptype: 'gxp_mapquestsource', name: 'MapQuest', defaultServer: true};
         service_.addServer(config);
@@ -787,7 +800,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       return addSearchResults(searchUrl, server, service_.reformatLayerConfigs);
     };
 
-    this.populateLayersConfigInelastic = function(server, deferredResponse) {
+    this.populateLayersConfigInelastic = function(server, force, deferredResponse) {
       // prevent getCapabilities request until ran by the user.
       if (server.lazy !== true || force === true || server.mapLayerRequiresServer === true) {
         var parser = new ol.format.WMSCapabilities();
@@ -894,6 +907,15 @@ var SERVER_SERVICE_USE_PROXY = true;
             {Title: 'MapQuestSat', Name: 'sat', sourceParams: {layer: 'sat'}},
             {Title: 'MapQuestHybrid', Name: 'hyb', sourceParams: {layer: 'hyb'}},
             {Title: 'MapQuestOSM', Name: 'osm', sourceParams: {layer: 'osm'}}
+          ];
+          deferredResponse.resolve(server);
+        } else if (server.ptype === 'gxp_arcrestsource') {
+          server.defaultServer = true;
+          if (!goog.isDefAndNotNull(server.name)) {
+            server.name = 'Esri';
+          }
+          server.layersConfig = [
+            {Title: 'World Topographic', Name: 'world_topo', sourceParams: {layer: 'world_topo'}}
           ];
           deferredResponse.resolve(server);
         } else if (server.ptype === 'gxp_osmsource') {
@@ -1029,7 +1051,7 @@ var SERVER_SERVICE_USE_PROXY = true;
             // service_.populateLayersConfigElastic(server, null);
             deferredResponse.resolve(server);
           } else {
-            deferredResponse = service_.populateLayersConfigInelastic(server, deferredResponse);
+            deferredResponse = service_.populateLayersConfigInelastic(server, force, deferredResponse);
           }
         } else {
           deferredResponse.reject();

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -87,6 +87,13 @@
           {
             'ptype': 'gxp_osmsource',
             'name': 'OpenStreetMap'
+          },
+          {
+            ptype: 'gxp_arcrestsource',
+            name: 'Esri',
+            defaultServer: true,
+            alwaysAnonymous: true,
+            url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/'
           }
         ],
         elasticLayerConfig: {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -721,6 +721,22 @@
           } else {
             console.log('====[ Error: could not create base layer.');
           }
+        } else if (server.ptype === 'gxp_arcrestsource') {
+          var attribution = new ol.Attribution({
+            html: 'Tiles &copy; <a href="' + server.url + '">ArcGIS</a>'
+          });
+          layer = new ol.layer.Tile({
+            metadata: {
+              serverId: server.id,
+              name: minimalConfig.name,
+              title: fullConfig.Title
+            },
+            visible: minimalConfig.visibility,
+            source: new ol.source.XYZ({
+              attributions: [attribution],
+              url: server.url + 'tile/{z}/{y}/{x}'
+            })
+          });
         } else if (server.ptype === 'gxp_tilejsonsource') {
           //currently we assume only one layer per 'server'
           var jsontile_source = server.layersConfig[0].TileJSONSource;


### PR DESCRIPTION
This PR adds support in the map service and server service for the Esri World Topographic map and also fixes a couple of small Registry-related bugs. Users can now add the World Topo layer from the server modal. 

