### PR TITLE
Handle EPSG:4326 Esri WMTS Services

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -477,9 +477,10 @@ var SERVER_SERVICE_USE_PROXY = true;
         config = {
           ptype: 'gxp_arcrestsource',
           name: 'Esri',
+          proj: 'EPSG:4326',
           defaultServer: true,
           alwaysAnonymous: true,
-          url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/'
+          url: 'https://services.arcgisonline.com/arcgis/rest/services/NGS_Topo_US_2D/MapServer/'
         };
         service_.addServer(config);
       } else {
@@ -915,7 +916,7 @@ var SERVER_SERVICE_USE_PROXY = true;
             server.name = 'Esri';
           }
           server.layersConfig = [
-            {Title: 'World Topographic', Name: 'world_topo', sourceParams: {layer: 'world_topo'}}
+            {Title: 'NGS Topographic', Name: 'NGS_Topo_US_2D', proj: 'EPSG:4326', sourceParams: {layer: 'NGS_Topo_US_2D'}}
           ];
           deferredResponse.resolve(server);
         } else if (server.ptype === 'gxp_osmsource') {

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -56,8 +56,8 @@
           abstract: ''
         },
         map: {
-          projection: 'EPSG:900913',
-          center: [-9707182.048613328, 1585691.7893914054],
+          projection: 'EPSG:4326',
+          center: [0, 0],
           zoom: 1,
           layers: [
             {
@@ -87,13 +87,6 @@
           {
             'ptype': 'gxp_osmsource',
             'name': 'OpenStreetMap'
-          },
-          {
-            ptype: 'gxp_arcrestsource',
-            name: 'Esri',
-            defaultServer: true,
-            alwaysAnonymous: true,
-            url: 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/'
           }
         ],
         elasticLayerConfig: {


### PR DESCRIPTION
This PR supports Esri WMTS base maps that rely on EPSG:4326. The tiling scheme is slightly different for these, hence the `tileUrlFunction` that gets used in the layer initialization.

