### PR TITLE
fix for default geoserver url

### DIFF
--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -76,7 +76,7 @@
         },
         sources: [
           {
-            'url': (location.host + '/geoserver/web/'),
+            'url': (location.host + '/geoserver/wms/'),
             'restUrl': '/gs/rest',
             'ptype': 'gxp_wmscsource',
             'name': 'Local GeoServer',


### PR DESCRIPTION
This pr fixes the base url for geoserver. It should be /web but /wms

