### PR TITLE
Removed placeholder translation which fails in IE

### DIFF
--- a/src/common/map/partial/savemap.tpl.html
+++ b/src/common/map/partial/savemap.tpl.html
@@ -7,7 +7,7 @@
             </div>
 
             <div class="form-group">
-                <label for="mapAbstract">{{ 'abstract' | translate }}</label><textarea id="mapAbstract" ng-model="mapService.abstract" class="form-control" rows="4" value="{{mapService.abstract}}" placeholder="{{mapService.abstract || ('abstract' | translate)}}"></textarea>
+                <label for="mapAbstract">{{ 'abstract' | translate }}</label><textarea id="mapAbstract" ng-model="mapService.abstract" class="form-control" rows="4" value="{{mapService.abstract}}">{{mapService.abstract}}</textarea>
             </div>
 
         </div>


### PR DESCRIPTION
## What does this PR do?

Removes @placeholder from <textarea> in Map Save dialog.  This fixes the bug in translation bug for IE where an error dialog would be displayed.

### Screenshot

### Related Issue

IE has quirks with handling <textarea>s.  This removes a translation directive that was throwing up an error dialog by removing the "placeholder" attribute. The abstract content was moved into the text area body to allow it to be populated when an abstract has already been created.

refs: JIRA / NODE-512 (commit message erroneously refers to 522)