### PR TITLE
Add Port Support and Fix Catalog List Startup Bug

### DIFF
--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -49,6 +49,9 @@
     this.$get = function($window, $http, $cookies, $location, $translate) {
       service_ = this;
       var serverLocation = $location.protocol() + '://' + $location.host();
+      if ($location.port() != 80) {
+        serverLocation += ':' + $location.port();
+      }
 
       this.configuration = {
         about: {

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,12 @@
 <% if (!(typeof django === 'undefined') && (django)) { %>
     {% get_current_language as language%}
 <script type="text/javascript">
-    var catalogList = JSON.parse("{{ CATALOGLIST|safe }}".replace(/'/g, '"'));
+    var catalogList = [];
+    try {
+        catalogList = JSON.parse("{{ CATALOGLIST|safe }}".replace(/'/g, '"'));
+    } catch(err) {
+        console.warn('No catalogs in CATALOGLIST');
+    }
     var registryEnabled = function(){
       return "{{ REGISTRY }}".toLowerCase() === "true" || true ? true : false;
     };


### PR DESCRIPTION
## What does this PR do?

* Adds the ability to detect and properly append the port to the base URL.
* When a catalog list is empty, it's JSON fails to parse, this wraps catalog parsing in a try {} statement to keep it from preventing proper startup.

### Screenshot

### Related Issue

No ticket/issue at this time. I found it during dev-environment standup.

MapLoom's configuration service was not honouring running on ports other than 80