### PR TITLE
Removed http schema from URLs

### DIFF
--- a/geonode_config.js
+++ b/geonode_config.js
@@ -4,8 +4,8 @@ var conf = {
   'userprofilename':'bobby',
   'userprofileemail':'bobby@bob.com',
   'proxy':'/proxy/?url=',
-  'nominatimUrl':'http://nominatim.openstreetmap.org',
-  'printService':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/pdf/',
+  'nominatimUrl':'//nominatim.openstreetmap.org',
+  'printService':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/pdf/',
   'rest':'/maps/',
   'ajaxLoginUrl':'/account/ajax_login',
   'homeUrl':'/',
@@ -17,8 +17,8 @@ var conf = {
       'region':'north'
     }
   ],
-  'localGeoServerBaseUrl':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/',
-  'localCSWBaseUrl':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw',
+  'localGeoServerBaseUrl':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/',
+  'localCSWBaseUrl':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw',
   'csrfToken':'au2a6uZO9A42lmsYLOGwkhUfgLFJxgY2',
   'tools':[
     {
@@ -84,7 +84,7 @@ var conf = {
         'opacity':1,
         'args':[
           'bluemarble',
-          'http://maps.opengeo.org/geowebcache/service/wms',
+          '//maps.opengeo.org/geowebcache/service/wms',
           {
             'layers':[
               'bluemarble'
@@ -146,7 +146,7 @@ var conf = {
               'legend':{
                 'height':'20',
                 'width':'20',
-                'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…%2Fpng&width=20&height=20&layer=estaciones_temporales_de_primeros_auxilios',
+                'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…%2Fpng&width=20&height=20&layer=estaciones_temporales_de_primeros_auxilios',
                 'format':'image/png'
               },
               'name':'estaciones_temporales_de_primeros_auxilios'
@@ -172,12 +172,12 @@ var conf = {
           'fixedWidth':0,
           'metadataURLs':[
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=24ad7ac3-df59-4a61-b09a-836a27d96b9e',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=24ad7ac3-df59-4a61-b09a-836a27d96b9e',
               'type':'FGDC',
               'format':'text/xml'
             },
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=24ad7ac3-df59-4a61-b09a-836a27d96b9e',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=24ad7ac3-df59-4a61-b09a-836a27d96b9e',
               'type':'TC211',
               'format':'text/xml'
             }
@@ -275,7 +275,7 @@ var conf = {
               'legend':{
                 'height':'20',
                 'width':'20',
-                'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…egendGraphic&format=image%2Fpng&width=20&height=20&layer=incidentes_copeco',
+                'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…egendGraphic&format=image%2Fpng&width=20&height=20&layer=incidentes_copeco',
                 'format':'image/png'
               },
               'name':'incidentes_copeco'
@@ -301,12 +301,12 @@ var conf = {
           'fixedWidth':0,
           'metadataURLs':[
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=1bf7e5bc-e3be-4a44-bc2a-d6ff96d815e7',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=1bf7e5bc-e3be-4a44-bc2a-d6ff96d815e7',
               'type':'FGDC',
               'format':'text/xml'
             },
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=1bf7e5bc-e3be-4a44-bc2a-d6ff96d815e7',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=1bf7e5bc-e3be-4a44-bc2a-d6ff96d815e7',
               'type':'TC211',
               'format':'text/xml'
             }
@@ -404,7 +404,7 @@ var conf = {
               'legend':{
                 'height':'20',
                 'width':'20',
-                'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…gendGraphic&format=image%2Fpng&width=20&height=20&layer=puestos_de_control',
+                'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…gendGraphic&format=image%2Fpng&width=20&height=20&layer=puestos_de_control',
                 'format':'image/png'
               },
               'name':'puestos_de_control'
@@ -430,12 +430,12 @@ var conf = {
           'fixedWidth':0,
           'metadataURLs':[
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=6771c2ef-25c1-4878-8e0e-2847ef2b92b6',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=6771c2ef-25c1-4878-8e0e-2847ef2b92b6',
               'type':'FGDC',
               'format':'text/xml'
             },
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=6771c2ef-25c1-4878-8e0e-2847ef2b92b6',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=6771c2ef-25c1-4878-8e0e-2847ef2b92b6',
               'type':'TC211',
               'format':'text/xml'
             }
@@ -533,7 +533,7 @@ var conf = {
               'legend':{
                 'height':'20',
                 'width':'20',
-                'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…t=image%2Fpng&width=20&height=20&layer=zonas_de_aterrizaje_de_helicopteros',
+                'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms?request=Ge…t=image%2Fpng&width=20&height=20&layer=zonas_de_aterrizaje_de_helicopteros',
                 'format':'image/png'
               },
               'name':'zonas_de_aterrizaje_de_helicopteros'
@@ -559,12 +559,12 @@ var conf = {
           'fixedWidth':0,
           'metadataURLs':[
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=7f6dec65-39ee-4ac7-8e76-ed2ca9b9363f',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=7f6dec65-39ee-4ac7-8e76-ed2ca9b9363f',
               'type':'FGDC',
               'format':'text/xml'
             },
             {
-              'href':'http://ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=7f6dec65-39ee-4ac7-8e76-ed2ca9b9363f',
+              'href':'//ec2-174-129-197-156.compute-1.amazonaws.com/catalogue/csw?outputsche…&version=2.0.2&elementsetname=full&id=7f6dec65-39ee-4ac7-8e76-ed2ca9b9363f',
               'type':'TC211',
               'format':'text/xml'
             }
@@ -653,7 +653,7 @@ var conf = {
     },
     '2':{
       'title':'Local Geoserver',
-      'url':'http://ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms',
+      'url':'//ec2-174-129-197-156.compute-1.amazonaws.com/geoserver/wms',
       'baseParams':{
         'VERSION':'1.1.1',
         'REQUEST':'GetCapabilities',

--- a/src/common/addlayers/AddServerDirective.js
+++ b/src/common/addlayers/AddServerDirective.js
@@ -62,11 +62,11 @@
 
             scope.getPlaceholder = function() {
               if (scope.type === 'WMS') {
-                return 'http://url/geoserver/wms';
+                return '//url/geoserver/wms';
               } else if (scope.type === 'TMS') {
-                return 'http://url/1.0.0/';
+                return '//url/1.0.0/';
               } else if (scope.type === 'MapBox') {
-                return 'http://api.tiles.mapbox.com/v4';
+                return '//api.tiles.mapbox.com/v4';
               }
             };
 
@@ -112,7 +112,7 @@
 
                         var serverBaseUrl = urlRemoveLastRoute(scope.server.url);
                         var serverAuthenticationUrl = serverBaseUrl + '/rest/settings.json';
-                        serverAuthenticationUrl = serverAuthenticationUrl.replace('http://', 'http://null:null@');
+                        serverAuthenticationUrl = serverAuthenticationUrl.replace('//', '//null:null@');
                         ignoreNextScriptError = true;
                         $.ajax({
                           url: serverAuthenticationUrl,

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -299,7 +299,7 @@ var SERVER_SERVICE_USE_PROXY = true;
                 // remove the 'wms endpoint'
                 var serverBaseUrl = urlRemoveLastRoute(server.url);
                 var serverAuthenticationUrl = serverBaseUrl + '/rest/settings.json';
-                serverAuthenticationUrl = serverAuthenticationUrl.replace('http://', 'http://null:null@');
+                serverAuthenticationUrl = serverAuthenticationUrl.replace('//', '//null:null@');
                 ignoreNextScriptError = true;
                 $.ajax({
                   url: serverAuthenticationUrl,
@@ -410,7 +410,7 @@ var SERVER_SERVICE_USE_PROXY = true;
                   // remove the 'wms endpoint'
                   var serverBaseUrl = urlRemoveLastRoute(server.url);
                   var serverAuthenticationUrl = serverBaseUrl + '/rest/settings.json';
-                  serverAuthenticationUrl = serverAuthenticationUrl.replace('http://', 'http://null:null@');
+                  serverAuthenticationUrl = serverAuthenticationUrl.replace('//', '//null:null@');
                   ignoreNextScriptError = true;
                   $.ajax({
                     url: serverAuthenticationUrl,
@@ -636,8 +636,8 @@ var SERVER_SERVICE_USE_PROXY = true;
 
     var createHyperSearchLayerObject = function(layerInfo, serverId) {
       /* Temporaly script to delete ":" extra info in layerInfo.tile_url
-      * before : http://localhost/registry/hypermap/layer/44/map/wmts/osm:placenames_capital/default_grid/1/1/0.png
-      * after: http://localhost/registry/hypermap/layer/44/map/wmts/placenames_capital/default_grid/1/1/0.png
+      * before : //localhost/registry/hypermap/layer/44/map/wmts/osm:placenames_capital/default_grid/1/1/0.png
+      * after:   //localhost/registry/hypermap/layer/44/map/wmts/placenames_capital/default_grid/1/1/0.png
       */
       if (layerInfo.tile_url) {
         var tile_url_splited = layerInfo.tile_url.split(':');
@@ -910,7 +910,6 @@ var SERVER_SERVICE_USE_PROXY = true;
     };
 
     this.populateLayersConfigElastic = function(server, filterOptions) {
-      //var searchUrl = 'http://beta.mapstory.org/api/layers/search/?is_published=true&limit=100';
       var searchUrl = '/api/layers/search/?is_published=true&limit=100';
       var searchParams = {};
       if (filterOptions !== null) {

--- a/src/common/addlayers/ServerService.spec.js
+++ b/src/common/addlayers/ServerService.spec.js
@@ -175,7 +175,7 @@ describe('addLayers/ServerService', function() {
       });
       it('calls reformatLayerConfigs with a geoserver URL', function() {
         spyOn(serverService, 'reformatLayerConfigs');
-        var geoserver_config = serverService.getServerByUrl('http://server/geoserver/wms');
+        var geoserver_config = serverService.getServerByUrl('//server/geoserver/wms');
         serverService.populateLayersConfigElastic(geoserver_config, {});
         $httpBackend.flush();
         expect(serverService.reformatLayerConfigs).toHaveBeenCalledWith([], geoserver_config.id);
@@ -293,7 +293,7 @@ describe('addLayers/ServerService', function() {
       });
       it('calls reformatLayerConfigs with a geoserver URL', function() {
         spyOn(serverService, 'reformatConfigForFavorites');
-        var geoserver_config = serverService.getServerByUrl('http://server/geoserver/wms');
+        var geoserver_config = serverService.getServerByUrl('//server/geoserver/wms');
         serverService.addSearchResultsForFavorites(geoserver_config, {});
         $httpBackend.flush();
         // The GeoServer server is usually configured in server id 1 or 2.

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -53,6 +53,14 @@
         serverLocation += ':' + $location.port();
       }
 
+      // Remove the schema from a URL
+      var stripUrl = function(url) {
+        if (url.substring(0, 4) == 'http') {
+          return url.substring(url.indexOf('//'));
+        }
+        return url;
+      };
+
       this.configuration = {
         about: {
           title: $translate.instant('new_map'),
@@ -79,7 +87,7 @@
         },
         sources: [
           {
-            'url': (serverLocation + '/geoserver/wms'),
+            'url': stripUrl(serverLocation + '/geoserver/wms'),
             'restUrl': '/gs/rest',
             'ptype': 'gxp_wmscsource',
             'name': 'Local GeoServer',
@@ -104,7 +112,7 @@
         id: 0,
         proxy: '/proxy/?url=',
         useProxy: false,
-        nominatimUrl: 'http://nominatim.openstreetmap.org',
+        nominatimUrl: '//nominatim.openstreetmap.org',
         fileserviceUrlTemplate: '/api/fileservice/view/{}',
         fileserviceUploadUrl: '/api/fileservice/',
         registryEnabled: true,

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -514,7 +514,7 @@
           //TODO: translate
           deferredResponse.reject('epsgCode could not be converted to valid number');
         } else {
-          var url = 'http://epsg.io/' + epsgCodeAsNumber + '.js';
+          var url = '//epsg.io/' + epsgCodeAsNumber + '.js';
           httpService_.get(url).then(function(response) {
             if (goog.isDefAndNotNull(response) && goog.isDefAndNotNull(response.data) && response.data.indexOf('proj4.defs(') === 0) {
               try {
@@ -703,7 +703,7 @@
 
           var parms = {
             //url: 'http://api.tiles.mapbox.com/v3/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ',
-            url: 'http://api.tiles.mapbox.com/v4/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ',
+            url: '//api.tiles.mapbox.com/v4/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ',
             crossOrigin: true
           };
           var mbsource = new ol.source.TileJSON(parms);

--- a/src/index.html
+++ b/src/index.html
@@ -46,10 +46,12 @@
       return "{{ NOMINATIM_SEARCH }}".toLowerCase() === "true" || true ? true : false;
     };
     var trimUrl = function(url){
+        // remove any trailing "/"s from the URLs
         if (url[url.length - 1] == '/') {
-            return url.substring(0, url.length - 1);
+            url = url.substring(0, url.length - 1);
         }
-        return url;
+        // strip any schema off of the URL
+        return url.substring(url.indexOf('//'));
     };
 
     config =  {
@@ -59,8 +61,8 @@
         userprofilename: {% if user.is_authenticated %} "{{ user.get_full_name }}" {% else %} undefined {% endif %},
         userprofileemail: {% if user.is_authenticated %} "{{ user.email }}" {% else %} undefined {% endif %},
         proxy: "/proxy/?url=",
-        nominatimUrl: "http://nominatim.openstreetmap.org",
-        printService: "{{GEOSERVER_BASE_URL}}pdf/",
+        nominatimUrl: "//nominatim.openstreetmap.org",
+        printService: trimUrl("{{GEOSERVER_BASE_URL}}pdf")+'/',
         /* The URL to a REST map configuration service.  This service
          * provides listing and, with an authenticated user, saving of
          * maps on the server for sharing and editing.
@@ -89,8 +91,14 @@
         nominatimSearchEnabled: nominatimSearchEnabled(),
         unifiedLayerDialog: unifiedDialogEnabled()
     };
-    console.log('CONFIG', config);
     goog.object.extend( config, {{ config|safe }});
+    // clean up any of the sources URLs
+    for (var src_key in config.sources) {
+        if (goog.isDefAndNotNull(config.sources[src_key].url)) {
+            config.sources[src_key].url = trimUrl(config.sources[src_key].url);
+        }
+    }
+    console.log('CONFIG', config);
 </script>
 <% } %>
 


### PR DESCRIPTION
This changeset is necessary to prevent MapLoom from trying to load http
schema URLs when running on HTTPS.  When http URLs are accessed the end user
will get a mixed content warning which can cause confusion and make
potentially insecure requests.

All configured sources will also be stripped of their leading schema in order
to prevent them from being accessed without HTTPs.

## What does this PR do?

Prevents "http" access when the application is loaded over "https".

### Screenshot

### Related Issue

NODE-341
