### PR TITLE
Refresh service fixed for mixed layer types

### DIFF
--- a/src/common/refresh/RefreshService.js
+++ b/src/common/refresh/RefreshService.js
@@ -219,6 +219,8 @@
               mapService_.dumpTileCache(metadata.uniqueID);
               nextLayer(nextIndex);
             }
+          } else {
+            nextLayer(nextIndex);
           }
         };
         processLayer(layers[0], 1);


### PR DESCRIPTION
When a layer was not a GeoGig layer it would not iterate the refresh loop to check the next layer,
this has been fixed

## What does this PR do?

Fixes the GeoGig test loop in the RefreshService.

### Screenshot

### Related Issue

NODE-256
