### PR TITLE
Fix GeoGig with Unified Search

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -735,7 +735,8 @@ var SERVER_SERVICE_USE_PROXY = true;
           author: author(layer),
           detail_url: layer.detail_url,
           source: server.name,
-          uuid: layer.uuid
+          uuid: layer.uuid,
+          geogig_link: layer.geogig_link
         });
       }
       return configs;

--- a/src/common/geogig/GeoGigService.js
+++ b/src/common/geogig/GeoGigService.js
@@ -415,8 +415,15 @@
       if (goog.isDefAndNotNull(layer)) {
         var metadata = layer.get('metadata');
         if (!goog.isDefAndNotNull(metadata.isGeoGig)) {
+          var splitGeogig = null;
           if (goog.isDefAndNotNull(fullConfig.Identifier) && goog.isDefAndNotNull(fullConfig.Identifier[0])) {
-            var splitGeogig = fullConfig.Identifier[0].replace('geoserver://', '').split(':');
+            splitGeogig = fullConfig.Identifier[0].replace('geoserver://', '').split(':');
+          } else if (goog.isDefAndNotNull(fullConfig.geogig_link)) {
+            var repo_name = fullConfig.geogig_link.split('/').pop();
+            var native_name = fullConfig.name.split(':').pop();
+            splitGeogig = [repo_name, native_name];
+          }
+          if (splitGeogig !== null) {
             if (goog.isArray(splitGeogig) && (splitGeogig.length === 2 || splitGeogig.length === 3)) {
               var repoName = splitGeogig[0];
               var nativeName = splitGeogig[1];

--- a/src/common/history/HistoryPanelDirective.js
+++ b/src/common/history/HistoryPanelDirective.js
@@ -4,8 +4,8 @@
   module.directive('loomHistoryPanel',
       function($rootScope, $timeout, $translate, diffService, dialogService, historyService, pulldownService) {
         return {
-          restrict: 'C',
-          replace: true,
+          //restrict: 'C',
+          //replace: true,
           templateUrl: 'history/partial/historypanel.tpl.html',
           link: function(scope, element, attrs) {
             scope.loadingDiff = false;
@@ -47,7 +47,10 @@
             }
 
             scope.getCommitAuthor = function(commit) {
-              return commit.author['name'].length > 0 ? commit.author['name'] : $translate.instant('anonymous');
+              if (goog.isDefAndNotNull(commit.author) && goog.isDefAndNotNull(commit.author['name'])) {
+                return commit.author['name'].length > 0 ? commit.author['name'] : $translate.instant('anonymous');
+              }
+              return $translate.instant('anonymous');
             };
 
             scope.getCommitTime = function(commit) {

--- a/src/common/history/HistoryPanelDirective.spec.js
+++ b/src/common/history/HistoryPanelDirective.spec.js
@@ -1,0 +1,60 @@
+describe('HistoryPanelDirective', function(){
+  var element, scope, compiledElement, configService;
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_history'));
+  beforeEach(module('history/partial/historypanel.tpl.html'));
+     //templateUrl: 'history/partial/historypanel.tpl.html',
+
+  beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_) {
+    scope = $rootScope.$new();
+    element = angular.element('<div loom-history-panel></div>');
+    compiledElement = $compile(element)(scope);
+    scope.$digest();
+    configService = _configService_;
+  }));
+
+  describe('Get Commit Author', function(){
+    var anon = 'Anonymous';
+    it('should return the name of the author', function() {
+      var namen = 'santa claus';
+      var author = compiledElement.scope().getCommitAuthor({author: {'name' : namen}});
+      expect(author).toBe(namen);
+    });
+    it('undefined author should return anonymous', function(){
+      var author = compiledElement.scope().getCommitAuthor({});
+      expect(author).toBe(anon);
+    });
+    it('null author name should return anonymous', function(){
+      var author = compiledElement.scope().getCommitAuthor({author: {'name' : null}});
+      expect(author).toBe(anon);
+    });
+  });
+
+/*
+  describe('createOlFeatureBasedOnChange', function(){
+    it('should return a valid OpenLayers feature object', function(){
+      var diffLayer = new ol.layer.Vector({
+        source: new ol.source.Vector({
+          parser: null
+        })
+      });
+      var validationFeature;
+      var olChangeFeature = diffService.createOlFeatureBasedOnChange(modifiedChange, repoId);
+      diffLayer.getSource().addFeature(olChangeFeature);
+      diffLayer.getSource().forEachFeature(function(iterFeature){
+        if (iterFeature === olChangeFeature) {
+          validationFeature = iterFeature;
+        }
+      });
+      expect(olChangeFeature).toBe(validationFeature);
+    });
+  });
+
+  describe('findChangeLayer', function(){
+    it('should return the map layer to which the change object belongs', function(){
+      var testLayer = diffService.findChangeLayer(modifiedChange, repoId, [mockLayer]);
+      expect(testLayer).toBe(mockLayer);
+    });
+  });
+*/
+});

--- a/src/common/history/HistoryPanelDirective.spec.js
+++ b/src/common/history/HistoryPanelDirective.spec.js
@@ -3,7 +3,6 @@ describe('HistoryPanelDirective', function(){
   beforeEach(module('MapLoom'));
   beforeEach(module('loom_history'));
   beforeEach(module('history/partial/historypanel.tpl.html'));
-     //templateUrl: 'history/partial/historypanel.tpl.html',
 
   beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_) {
     scope = $rootScope.$new();
@@ -15,46 +14,22 @@ describe('HistoryPanelDirective', function(){
 
   describe('Get Commit Author', function(){
     var anon = 'Anonymous';
+    // check whether Santa Claus exists.
     it('should return the name of the author', function() {
       var namen = 'santa claus';
       var author = compiledElement.scope().getCommitAuthor({author: {'name' : namen}});
       expect(author).toBe(namen);
     });
+    // Then check for an undefined author
     it('undefined author should return anonymous', function(){
       var author = compiledElement.scope().getCommitAuthor({});
       expect(author).toBe(anon);
     });
+    // finally check for a scenario in which the author's name 
+    //   is null.
     it('null author name should return anonymous', function(){
       var author = compiledElement.scope().getCommitAuthor({author: {'name' : null}});
       expect(author).toBe(anon);
     });
   });
-
-/*
-  describe('createOlFeatureBasedOnChange', function(){
-    it('should return a valid OpenLayers feature object', function(){
-      var diffLayer = new ol.layer.Vector({
-        source: new ol.source.Vector({
-          parser: null
-        })
-      });
-      var validationFeature;
-      var olChangeFeature = diffService.createOlFeatureBasedOnChange(modifiedChange, repoId);
-      diffLayer.getSource().addFeature(olChangeFeature);
-      diffLayer.getSource().forEachFeature(function(iterFeature){
-        if (iterFeature === olChangeFeature) {
-          validationFeature = iterFeature;
-        }
-      });
-      expect(olChangeFeature).toBe(validationFeature);
-    });
-  });
-
-  describe('findChangeLayer', function(){
-    it('should return the map layer to which the change object belongs', function(){
-      var testLayer = diffService.findChangeLayer(modifiedChange, repoId, [mockLayer]);
-      expect(testLayer).toBe(mockLayer);
-    });
-  });
-*/
 });

--- a/src/index.html
+++ b/src/index.html
@@ -157,7 +157,7 @@
 
           <div class="panel" ng-show="layersPanel">
             <div ng-show="registryEnabled && !unifiedLayerDialog" class="panel-heading" data-parent="#pulldown-content">
-              <span translate="registry">Registry</span><span>*{{unifiedLayerDialog}}*</span>
+              <span translate="registry">Registry</span>
               <div ng-show="addLayers" stop-event='click' ng-controller="modalToggle" ng-click="toggleModal('#registry-layer-dialog')"
                    tooltip-placement="top" tooltip="{{'registry_layer_btn' | translate}}" tooltip-append-to-body="true"
                    class="glyphicon glyphicon-plus-sign panel-header-button pull-right"></div>
@@ -213,8 +213,8 @@
                    tooltip-placement="top" tooltip="{{'history_summary' | translate}}" tooltip-append-to-body="true"
                    class="glyphicon glyphicon-list-alt pull-right panel-header-button"></div>
             </div>
-            <div id="history-panel" class="loom-history-panel panel-collapse collapse pulldown-panel">History goes
-              here.
+            <div id="history-panel" class="panel-collapse collapse pulldown-panel">
+                <div loom-history-panel></div>
             </div>
           </div>
           <div class="panel" ng-show="diffPanel" ng-controller="LoomDiffController">


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs:
1. Geogig was not showing up in the Unified Layer search because there was no hooks in the Layer's API in GeoNode.  This now supports a "geogig_link" attribute when returned from that API.
2. Fixes bugs when the author and/or author's name is undefined.

### Screenshot

### Related Issue

NODE-562, NODE-628
