### PR TITLE
Fixed IE Map Savings / Recall Bugs

### DIFF
--- a/src/common/map/partial/savemap.tpl.html
+++ b/src/common/map/partial/savemap.tpl.html
@@ -7,7 +7,7 @@
             </div>
 
             <div class="form-group">
-                <label for="mapAbstract">{{ 'abstract' | translate }}</label><textarea id="mapAbstract" ng-model="mapService.abstract" class="form-control" rows="4" value="{{mapService.abstract}}">{{mapService.abstract}}</textarea>
+                <label for="mapAbstract">{{ 'abstract' | translate }}</label><textarea id="mapAbstract" ng-model="mapService.abstract" class="form-control" rows="4">mapService.abstract}}</textarea>
             </div>
 
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -158,7 +158,7 @@
 
             <div ng-show="true" class="panel">
                 <div class="panel-heading" data-toggle="collapse" data-parent="#pulldown-content" data-target="#measure-panel-content">
-                    <span translate="Measure">Measure</span>
+                    <span translate="measure">Measure</span>
                 </div>
                 <div id="measure-panel-content" class="panel-collapse collapse pulldown-panel">
                     <div loom-measurepanel></div>


### PR DESCRIPTION
Small translate module issues once again.
- IE does not like value= being set on <textarea>s
- Measure tool was using "Measure" instead of "measure" as the key.

## What does this PR do?

Fixes an IE bug that was causing the error dialog to appear.

### Screenshot

### Related Issue

NODE-26
NODE-512
