### PR TITLE
Bug/node 658 issues with layer names

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -525,13 +525,13 @@ var SERVER_SERVICE_USE_PROXY = true;
       }
     };
 
-    this.getFullLayerConfig = function(serverId, layerId) {
+    this.getFullLayerConfig = function(serverId, minimalConfig) {
       //Issue WMS request to get full layer config for mapService
       var result = q_.defer();
       var layerConfig = null;
       var server = service_.getRegistryLayerConfig();
       if (server.id != serverId) {
-        result.resolve(service_.getLayerConfig(serverId, layerId));
+        result.resolve(service_.getLayerConfig(serverId, minimalConfig));
         return result.promise;
       }
       var parser = new ol.format.WMSCapabilities();
@@ -561,14 +561,17 @@ var SERVER_SERVICE_USE_PROXY = true;
       return result.promise;
     };
 
-    this.getLayerConfig = function(serverId, layerId) {
+    this.getLayerConfig = function(serverId, layerConf) {
       var layersConfig = service_.getLayersConfig(serverId);
       var layerConfig = null;
+      var layerId = layerConf.uuid;
+      var layerName = layerConf.Name ? layerConf.Name : layerConf.name;
 
       for (var index = 0; index < layersConfig.length; index += 1) {
         //if (layersConfig[index].Name === layerName || (typeof layerName.split != 'undefined' &&
         //    layersConfig[index].Name === layerName.split(':')[1])) {
-        if (layersConfig[index].uuid == layerId) {
+        if ((goog.isDefAndNotNull(layersConfig[index].uuid) && layersConfig[index].uuid === layerId) ||
+            (!goog.isDefAndNotNull(layersConfig[index].uuid) && layersConfig[index].Name === layerName)) {
           layerConfig = layersConfig[index];
           if (goog.isDefAndNotNull(layerConfig.CRS)) {
             for (var code in layerConfig.CRS) {

--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -40,17 +40,31 @@
             };
 
             scope.getLegendUrl = function(layer) {
-              var url = null;
               var server = serverService.getServerById(layer.get('metadata').serverId);
+              var domain = '';
               if (goog.isDefAndNotNull(server.virtualServiceUrl)) {
                 domain = server.virtualServiceUrl;
               } else {
                 domain = server.url;
               }
-              url = domain + '?request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=' +
-                  layer.get('metadata').name + '&transparent=true&legend_options=fontColor:0xFFFFFF;' +
-                  'fontAntiAliasing:true;fontSize:14;fontStyle:bold;';
-              return url;
+
+              var params = {
+                request: 'GetLegendGraphic',
+                format: 'image/png',
+                width: '20', height: '20',
+                transparent: 'true',
+                legend_options: 'fontColor:0xFFFFFF;fontAntiAliasing:true;fontSize:14;fontStyle:bold;',
+                layer: layer.get('metadata').name
+              };
+
+              // parse the server url
+              var uri = new goog.Uri(domain);
+              // mix in the paramters
+              for (var key in params) {
+                uri.setParameterValue(key, params[key]);
+              }
+              // kick back the URL as a formatted string.
+              return uri.toString();
             };
 
             scope.$on('layer-added', function() {

--- a/src/common/legend/LegendDirective.spec.js
+++ b/src/common/legend/LegendDirective.spec.js
@@ -1,0 +1,105 @@
+/** Tests for the Legend Directive.
+ *
+ */
+describe('LegendDirective', function() {
+  var element, scope, compiledElement, configService, serverService, mapService;
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_legend'));
+  beforeEach(module('legend/partial/legend.tpl.html'));
+
+  beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_,
+                            _serverService_, _mapService_) {
+    scope = $rootScope.$new();
+    element = angular.element('<div class="loom-legend"></div>');
+    compiledElement = $compile(element)(scope);
+    scope.$digest();
+
+    configService = _configService_;
+    serverService = _serverService_;
+    mapService = _mapService_;
+
+    mapService.map.layers = null;
+    serverService.getServers().length = 0;
+    mapService.loadLayers();
+    scope.$apply();
+  }));
+  describe('basic render', function() {
+    it('creates a legend-container', function() {
+      expect(compiledElement.find('div#legend-container').length).toEqual(1);
+    });
+  });
+
+  describe('handle both ? and ?-free urls', function() {
+    it('should generate a GetLegendGraphic url', function() {
+      serverService.addServer({
+        'url': '//fake-uri.com/gs/wms',
+        'restUrl': '//fake-uri.com/fake-gs/rest',
+        'ptype': 'gxp_wmscsource',
+        'name': 'NO QUESTION',
+        'elastic': true,
+        'alwaysAnonymous': true,
+        'lazy': true
+      });
+
+      scope.$apply();
+
+      // get the server definition
+      var server = serverService.getServerByName('NO QUESTION');
+      // fake the WMS config
+      server.layersConfig = [{
+        Name: 'test1',
+        Title: 'test1'
+      }];
+
+      // add the layer to the map.
+      var layer = mapService.addLayer({
+        'name' : 'test1',
+        'title' : 'test1',
+        'source' : server.id,
+        'ptype' : server.ptype
+      });
+      scope.$apply();
+
+      // test the URL.
+      var legend_url = scope.getLegendUrl(layer);
+      expect(legend_url.split('?').length).toBe(2);
+    });
+    it('should drop the second "?"', function() {
+      serverService.addServer({
+        'url': '//fake-uri.com/gs/wms?oath=fake-auth',
+        'restUrl': '//fake-uri.com/fake-gs/rest',
+        'ptype': 'gxp_wmscsource',
+        'name': 'WITH QUESTION',
+        'elastic': true,
+        'alwaysAnonymous': true,
+        'lazy': true
+      });
+
+      scope.$apply();
+
+      // get the server definition
+      var server = serverService.getServerByName('WITH QUESTION');
+      // fake the WMS config
+      server.layersConfig = [{
+        Name: 'test2',
+        Title: 'test2'
+      }];
+
+      // add the layer to the map.
+      var layer = mapService.addLayer({
+        'name' : 'test2',
+        'title' : 'test2',
+        'source' : server.id,
+        'ptype' : server.ptype
+      });
+      scope.$apply();
+
+      // test the URL.
+      var legend_url = scope.getLegendUrl(layer);
+      expect(legend_url.split('?').length).toBe(2);
+    });
+
+  });
+});
+
+

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -565,7 +565,7 @@
 
       var fullConfig = null;
       if (goog.isDefAndNotNull(server)) {
-        fullConfig = serverService_.getLayerConfig(server.id, minimalConfig.uuid);
+        fullConfig = serverService_.getLayerConfig(server.id, minimalConfig);
       }
 
       if (goog.isDefAndNotNull(minimalConfig.registryConfig)) {


### PR DESCRIPTION
## What does this PR do?

Layers added from the search screen do not carry a 'uuid' that the
changes from Unified Search required.  This changes the getLayerConfig
function to look for a layer in any of two ways.
    
1. If a uuid is available then use the uuid.
2. If the layer does not have a uuid then do a simple name match.
    
This should provide a fix for a mislabeling of layers.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/21907963/769e3888-d8d7-11e6-9a88-630333c30547.png)

### Related Issue

NODE-658
