### PR TITLE
MapLoom version is now available in the UI.

### DIFF
--- a/src/common/map/MapSaveDirective.js
+++ b/src/common/map/MapSaveDirective.js
@@ -3,7 +3,7 @@
   var module = angular.module('loom_savemap_directive', []);
 
   module.directive('loomSaveMap',
-      function(mapService, configService, $translate) {
+      function(mapService, configService, $window, $translate) {
         return {
           restrict: 'AC',
           templateUrl: 'map/partial/savemap.tpl.html',
@@ -11,6 +11,10 @@
             scope.mapService = mapService;
             scope.configService = configService;
             scope.translate = $translate;
+
+            scope.version_string = $window.MAPLOOM_VERSION.version_string;
+            scope.build_date = $window.MAPLOOM_VERSION.build_date;
+
             function onResize() {
               var height = $(window).height();
               element.children('.modal-body').css('max-height', (height - 200).toString() + 'px');

--- a/src/common/map/partial/savemap.tpl.html
+++ b/src/common/map/partial/savemap.tpl.html
@@ -14,11 +14,22 @@
     </form>
 </div>
 <div class="modal-footer">
-    <button type="button" class="btn btn-default" data-dismiss="modal">{{'close_btn' | translate }}</button>
-  <button type="button" class="btn btn-primary" data-dismiss="modal" ng-disabled="!configService.username"
+  <div class="row">
+    <div class="col-xs-6 text-left">
+      <div class="loom-version">
+        <button class="btn btn-default btn-link" tooltip="MapLoom Version: {{ version_string }} ({{ build_date }})" >
+            <i class="glyphicon glyphicon-info-sign"></i>
+        </button>
+      </div>
+    </div>
+    <div class="col-xs-6">
+      <button type="button" class="btn btn-default" data-dismiss="modal">{{'close_btn' | translate }}</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" ng-disabled="!configService.username"
           ng-click="mapService.save(true)" ng-show="mapService.id" >{{'save_copy_btn' | translate}}</button>
-  <button type="button" class="btn btn-primary" data-dismiss="modal" ng-disabled="!configService.username"
+      <button type="button" class="btn btn-primary" data-dismiss="modal" ng-disabled="!configService.username"
           ng-click="mapService.save()">{{'save_btn' | translate}}</button>
+    </div>
+  </div>
 </div>
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,12 @@
 
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-COMPATIBLE" content="IE-Edge">
+  <script type="text/javascript">
+    window.MAPLOOM_VERSION = {
+        "version_string": "<%= version %>",
+        "build_date": "<%= grunt.template.today("yyyy-mm-dd") %>"
+    };
+  </script>
 
 <!-- compiled CSS --><% styles.forEach( function ( file ) { %>
     <% if (!(typeof django === 'undefined') && (django)) { %>


### PR DESCRIPTION
## What does this PR do?

Adds a method for checking the maploom version inside of the user interface.
It accessed by hovering over the "info" icon in the save map
dialog. There are not many default dialogs and this was a
predictable landing spot.  The icon itself is small and out of the
way.

The version is added into "scope" by using the window variable
MAPLOOM_VERSION, which is an object containing the version string
and the build date.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/1282291/22023081/55e52a64-dc8a-11e6-963f-e9f9a5b42170.png)

### Related Issue

NODE-661
