### PR TITLE
Changed the behaviour of the default wfs server.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -228,7 +228,9 @@ var SERVER_SERVICE_USE_PROXY = true;
       url = goog.isDefAndNotNull(server) ? service_.getMostSpecificUrl(server) : url;
       var currentDomain = locationService_.host();
       if (goog.isDefAndNotNull(url)) {
-        if (url.indexOf(currentDomain) > -1) {
+        if (url.indexOf(currentDomain) >= 0 && url.indexOf('geoserver') > 0) {
+          return '/geoserver/wfs';
+        } else if (url.indexOf(currentDomain) > -1) {
           wfsurl = location.protocol + '//' + location.host + '/wfsproxy/';
           return wfsurl;
         }

--- a/src/common/updatenotification/UpdateNotificationDirective.js
+++ b/src/common/updatenotification/UpdateNotificationDirective.js
@@ -43,7 +43,7 @@
                 }
               });
 
-              var geom = WKT.read(repoFeature.geometry);
+              var geom = WKT.read(repoFeature.geometry[0]);
               if (goog.isDefAndNotNull(crs)) {
                 geom.transform(crs, mapService.map.getView().getProjection());
               }


### PR DESCRIPTION
## What does this PR do?

JSESSIONID cookie is used to relate permission to geoserver,
but is limited to the /geoserver path.  This was not working with
/wfsproxy/. Also, GeoGig returns the geometry as an array and the
code assumed it was a simple attribute.

- New code is added to check that the geoserver is 'local' and
  will then do an automatic switch to use /wfs
- The WKT parser for notifications now gets the first element of the
  geometry array instead of the entire array.

### Screenshot

### Related Issue

NODE-668
