### PR TITLE
Tweak for wide ranging wkt.read bug.

### DIFF
--- a/src/common/utils/wktparser.js
+++ b/src/common/utils/wktparser.js
@@ -136,6 +136,10 @@ var readFeaturesFromString = function(str) {
 
 var WKT = {
   read: function(str) {
+    // if an array comes in, return the first feature.
+    if (Array.isArray(str)) {
+      return read(str[0]);
+    }
     return read(str);
   }
 };

--- a/src/common/utils/wktparser.spec.js
+++ b/src/common/utils/wktparser.spec.js
@@ -1,0 +1,22 @@
+/** Tests for the WKT Parser
+ *
+ */
+describe('wktparser', function() {
+  beforeEach(module('MapLoom'));
+
+  // don't ever test with 0 0 or -1 -1 as that
+  // can occasionally show up as default behaviour.
+  var test_point = 'POINT(2 2)';
+
+  it('parses a simple point', function() {
+    var g = WKT.read(test_point);
+    var wkt_out = (new ol.format.WKT()).writeGeometry(g);
+    expect(wkt_out).toEqual(test_point);
+  });
+  it('handles a feature in an array', function() {
+    var g = WKT.read([test_point]);
+    var wkt_out = (new ol.format.WKT()).writeGeometry(g);
+    expect(wkt_out).toEqual(test_point);
+  });
+});
+


### PR DESCRIPTION
GeoGig has changed to return an array of geometries instead
of a single geometry string.  In various parts of the application,
where the geogig change was passed around for comparison and parsing,
this was causing a number of failures.

## What does this PR do?

- The parser has been tweaked to detect when an array has been
  passed in and will parse the first geometry and return it.
- A test has been added to ensure that this functionality works
  correctly.

### Screenshot

### Related Issue

NODE-690
