### PR TITLE
Fix for back-button issue with invalid location.

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1474,7 +1474,7 @@
 
       for (var i = 0, ii = components.length; i < ii; i++) {
         // location starts with 'l='
-        if (components[i].substring(0, 2) == 'l=') {
+        if (components[i].substring(0, 2) === 'l=') {
           var loc = components[i].substring(2).split(',');
           return {
             center: [parseFloat(loc[0]), parseFloat(loc[1])],
@@ -1499,10 +1499,20 @@
       // if the hash are different, then do something...
       if (window_hash != current_hash) {
         // update the view
-        var view = getHashView(window_hash, this.map.getView());
+
         var map_view = this.map.getView();
-        map_view.setCenter(view.center);
-        map_view.setResolution(view.resolution);
+
+        var default_view = {
+          center: map_view.getCenter(),
+          resolution: map_view.getZoom()
+        };
+
+
+        var view = getHashView(window_hash, default_view);
+        if (view.resolution > 0) {
+          map_view.setCenter(view.center);
+          map_view.setResolution(view.resolution);
+        }
       }
     };
 


### PR DESCRIPTION
## What does this PR do?
If the user hit the back button too many times it could
throw an exception about the tileRange.  This was because the
resolution was being set to zero due to a set of undefiend
conditions.  This prevents the map from entering that
invalid state.

### Screenshot

### Related Issue

NODE-705