### PR TITLE
Fix for Forward button in Firefox.

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1500,9 +1500,11 @@
       if (window_hash != current_hash) {
         // update the view
         var view = getHashView(window_hash, this.map.getView());
-        var map_view = this.map.getView();
-        map_view.setCenter(view.center);
-        map_view.setResolution(view.resolution);
+        if (goog.isDefAndNotNull(view.center) && goog.isDefAndNotNull(view.center[0])) {
+          var map_view = this.map.getView();
+          map_view.setCenter(view.center);
+          map_view.setResolution(view.resolution);
+        }
       }
     };
 


### PR DESCRIPTION
## What does this PR do?

Under certain circumstances, Firefox was creating an undefined
center and/or resolutoin when using the forward and back buttons
to navigate.  This makes for a better test that avoids getting
into a spot where the map gets undefined coordinates.

### Screenshot

### Related Issue

NODE-711
