### PR TITLE
Fix for undef'd authors throwing exception.

### DIFF
--- a/src/common/diff/FeaturePanelDirective.js
+++ b/src/common/diff/FeaturePanelDirective.js
@@ -50,11 +50,26 @@
               if (scope.isConflictPanel) {
                 return '---------------------';
               }
-              if (goog.isDefAndNotNull(attribute) && goog.isDefAndNotNull(attribute.commit)) {
+
+              var author = null;
+              if (goog.isDefAndNotNull(attribute) &&
+                  goog.isDefAndNotNull(attribute.commit) && attribute.commit.length > 0 &&
+                  goog.isDefAndNotNull(attribute.commit[0].author)) {
+                             author = attribute.commit[0].author;
+              }
+
+              if (goog.isDefAndNotNull(author)) {
                 var returnString = '';
-                returnString += attribute.commit.author.name + ' - ';
-                var date = new Date(attribute.commit.author.timestamp);
-                returnString += date.toLocaleDateString() + ' @ ' + date.toLocaleTimeString();
+                if (goog.isDefAndNotNull(author.name)) {
+                  returnString += author.name;
+                } else {
+                  returnString += $translate.instant('anonymous');
+                }
+                if (goog.isDefAndNotNull(author.timestamp)) {
+                  returnString += ' - ';
+                  var date = new Date(author.timestamp);
+                  returnString += date.toLocaleDateString() + ' @ ' + date.toLocaleTimeString();
+                }
                 return returnString;
               }
               return '';

--- a/src/common/history/HistoryPopoverDirective.js
+++ b/src/common/history/HistoryPopoverDirective.js
@@ -14,36 +14,46 @@
               element.popover('destroy');
               return;
             }
-            var safeName = function(name) {
-              if (goog.isDefAndNotNull(name) && name.length > 0) {
-                return name;
+            var safeName = function(author) {
+              if (goog.isDefAndNotNull(author)) {
+                if (goog.isDefAndNotNull(author.name) && author.name.length > 0) {
+                  return author.name;
+                }
               }
               return $translate.instant('anonymous');
             };
-            var safeEmail = function(email) {
-              if (goog.isDefAndNotNull(email) && email.length > 0) {
-                return email;
+            var safeEmail = function(author) {
+              if (goog.isDefAndNotNull(author)) {
+                if (goog.isDefAndNotNull(author.email) && author.email.length > 0) {
+                  return author.email;
+                }
               }
               return $translate.instant('no_email');
             };
-            var prettyTime = function(time) {
-              var date = new Date(time);
-              return date.toLocaleDateString() + ' @ ' + date.toLocaleTimeString();
+            var prettyTime = function(meta) {
+              if (goog.isDefAndNotNull(meta) && goog.isDefAndNotNull(meta.timestamp)) {
+                var date = new Date(meta.timestamp);
+                return date.toLocaleDateString() + ' @ ' + date.toLocaleTimeString();
+              }
+              return '';
             };
             var prettyMessage = function() {
-              return scope.commit.message;
+              if (goog.isDefAndNotNull(scope.commit.message)) {
+                return scope.commit.message;
+              }
+              return '';
             };
 
             var content = '<div class="popover-label">' + $translate.instant('author_name') + ':</div>' +
-                '<div class="popover-value">' + safeName(scope.commit.author.name) + '</div>' +
+                '<div class="popover-value">' + safeName(scope.commit.author) + '</div>' +
                 '<div class="popover-label">' + $translate.instant('author_email') + ':</div>' +
-                '<div class="popover-value">' + safeEmail(scope.commit.author.email) + '</div>' +
+                '<div class="popover-value">' + safeEmail(scope.commit.author) + '</div>' +
                 '<div class="popover-label">' + $translate.instant('committer_name') + ':</div>' +
-                '<div class="popover-value">' + safeName(scope.commit.committer.name) + '</div>' +
+                '<div class="popover-value">' + safeName(scope.commit.committer) + '</div>' +
                 '<div class="popover-label">' + $translate.instant('committer_email') + ':</div>' +
-                '<div class="popover-value">' + safeEmail(scope.commit.committer.email) + '</div>' +
+                '<div class="popover-value">' + safeEmail(scope.commit.committer) + '</div>' +
                 '<div class="popover-label">' + $translate.instant('commit_time') + ':</div>' +
-                '<div class="popover-value">' + prettyTime(scope.commit.committer.timestamp) + '</div>' +
+                '<div class="popover-value">' + prettyTime(scope.commit.committer) + '</div>' +
                 '<div class="popover-label">' + $translate.instant('message') + ':</div>' +
                 '<div class="popover-value">' + prettyMessage() + '</div>';
 


### PR DESCRIPTION
## What does this PR do?

Undefined Authors were throwing exceptions when trying to view
the history panel. This commit fixes that by better handling
cases when the author, author's name, author's email, or the timestamp
is undefined.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/22694702/da84beb8-ed0d-11e6-8ffa-57ce483a2886.png)

### Related Issue

NODE-712
