### PR TITLE
Prevent the user from clicking on initial commit.

### DIFF
--- a/src/common/history/HistoryPanelDirective.js
+++ b/src/common/history/HistoryPanelDirective.js
@@ -60,7 +60,8 @@
             };
 
             scope.historyClicked = function(commit) {
-              if (scope.loadingDiff !== false) {
+              if (scope.loadingDiff !== false ||
+                  (commit.adds + commit.removes + commit.modifies) === 0) {
                 return;
               }
               commit.loading = true;
@@ -69,7 +70,7 @@
               var lastCommitId = '0000000000000000000000000000000000000000';
               if (goog.isDefAndNotNull(commit.parents) && goog.isObject(commit.parents)) {
                 if (goog.isDefAndNotNull(commit.parents.id)) {
-                  if (goog.isArray(commit.parents.id)) {
+                  if (goog.isArray(commit.parents.id) && goog.isDefAndNotNull(commit.parents.id[0])) {
                     lastCommitId = commit.parents.id[0];
                   } else {
                     lastCommitId = commit.parents.id;

--- a/src/common/history/HistoryPopoverDirective.js
+++ b/src/common/history/HistoryPopoverDirective.js
@@ -22,6 +22,8 @@
               }
               return $translate.instant('anonymous');
             };
+            scope.safeName = safeName;
+
             var safeEmail = function(author) {
               if (goog.isDefAndNotNull(author)) {
                 if (goog.isDefAndNotNull(author.email) && author.email.length > 0) {
@@ -30,6 +32,8 @@
               }
               return $translate.instant('no_email');
             };
+            scope.safeEmail = safeEmail;
+
             var prettyTime = function(meta) {
               if (goog.isDefAndNotNull(meta) && goog.isDefAndNotNull(meta.timestamp)) {
                 var date = new Date(meta.timestamp);
@@ -37,6 +41,8 @@
               }
               return '';
             };
+            scope.prettyTime = prettyTime;
+
             var prettyMessage = function() {
               if (goog.isDefAndNotNull(scope.commit.message)) {
                 return scope.commit.message;

--- a/src/common/history/HistoryPopoverDirective.spec.js
+++ b/src/common/history/HistoryPopoverDirective.spec.js
@@ -1,0 +1,68 @@
+describe('HistoryPopoverDirective', function(){
+  //var element, scope, compiledElement, configService;
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_history'));
+
+  beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_) {
+    scope = $rootScope.$new();
+    scope.commit = {};
+    element = angular.element('<div class="loom-history-popover"></div>');
+    compiledElement = $compile(element)(scope);
+    scope.$digest();
+    configService = _configService_;
+  }));
+
+  describe('check safeName', function() {
+    var anon = 'Anonymous';
+    // check whether Santa Claus exists.
+    it('should return the name of the author', function() {
+      var namen = 'santa claus';
+      var author = compiledElement.scope().safeName({'name' : namen});
+      expect(author).toBe(namen);
+    });
+    // Then check for an undefined author
+    it('undefined author should return anonymous', function(){
+      var author = compiledElement.scope().safeName({});
+      expect(author).toBe(anon);
+    });
+    // finally check for a scenario in which the author's name 
+    //   is null.
+    it('null author name should return anonymous', function(){
+      var author = compiledElement.scope().safeName({name: null});
+      expect(author).toBe(anon);
+    });
+    // check that anonymous returns for a null committer.
+    it('undefined author should return anonymous', function(){
+      var author = compiledElement.scope().safeName(undefined);
+      expect(author).toBe(anon);
+    });
+  });
+
+
+  describe('check safeEmail', function() {
+    var anon = 'No Email';
+    // check a given email address
+    it('should return the email address of the author', function() {
+      var email = 'super@email.io';
+      var author = compiledElement.scope().safeEmail({'email' : email});
+      expect(author).toBe(email);
+    });
+    // Then check for an undefined author
+    it('undefined author should return no_email', function(){
+      var author = compiledElement.scope().safeEmail({});
+      expect(author).toBe(anon);
+    });
+    // finally check for a scenario in which the author's email
+    //   is null.
+    it('null author email should return no_email', function(){
+      var author = compiledElement.scope().safeEmail({email: null});
+      expect(author).toBe(anon);
+    });
+    // check that no_email returns for a null committer.
+    it('undefined author should return no_email', function(){
+      var author = compiledElement.scope().safeEmail(undefined);
+      expect(author).toBe(anon);
+    });
+  });
+
+});

--- a/src/common/history/partial/historypanel.tpl.html
+++ b/src/common/history/partial/historypanel.tpl.html
@@ -1,7 +1,7 @@
 <div>
   <div class="history-scroll-pane">
     <ul class="list-group">
-      <li class="list-group-item loom-history-popover" ng-repeat="commit in log | filter:{visible:'true'}" ng-click="historyClicked(commit)">
+      <li class="list-group-item loom-history-popover" ng-repeat="commit in log | filter:{visible:'true'}" ng-click="historyClicked(commit)" ng-class="{'disabled' : ((commit.adds + commit.removes + commit.modifies) == 0)}">
         <div ng-if="isLoading(commit)" class="diff-loading loom-loading" spinner-hidden="false"></div>
         <div class="commit-summary progress">
           <div class="progress-bar progress-bar-add" ng-style="commit.summary.added">

--- a/src/common/history/style/history.less
+++ b/src/common/history/style/history.less
@@ -95,3 +95,12 @@
   width: 170px;
   font-size: 13px;
 }
+
+.loom-history-popover {
+    cursor: pointer;
+}
+
+.loom-history-popover.disabled {
+    background-color: #eee;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## What does this PR do?

When a layer's initial commit is clicked it would cause an error
as there is no 'previous' commit against which to diff.  The new code
now:

1. Adds a 'disabled' class to those entires.
2. Prevents the diff from being executed.
3. Changes the cursor and puts a grey background on those entries.


### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/22711727/e3834392-ed47-11e6-87fa-f660f84ecd6a.png)

### Related Issue

NODE-726
