### PR TITLE
Fix for datepicker throwing error.

### DIFF
--- a/src/common/utils/UtilsModule.js
+++ b/src/common/utils/UtilsModule.js
@@ -254,7 +254,6 @@
             hasValidDate = false;
           }
         };
-        updateDate();
 
         var handleInvalidDate = function(e) {
           e.stopPropagation();
@@ -321,6 +320,7 @@
           }
           updateDateTime();
         };
+        dateObjectChanged();
 
         scope.$watch('dateObject', dateObjectChanged);
 


### PR DESCRIPTION
## What does this PR do?

The date-picker was throwing an error if updateDate() was called
before the scope was able to set the date.  This was causing
an error dialog to be shown to the user when looking at the date panel.

Removing the extra call to "updateDate" and using  dateObjectChanged
has fixed the problem.


### Screenshot

### Related Issue

NODE-712
