### PR TITLE
Work around for safari table downloads.

### DIFF
--- a/src/common/tableview/TableViewService.js
+++ b/src/common/tableview/TableViewService.js
@@ -465,7 +465,38 @@
       this.currentPage = 0;
     };
 
+    this.getCSV_Safari = function() {
+      if (confirm('Safari does not support table filters. Proceeding will download all features.')) {
+        var metadata = this.selectedLayer.get('metadata');
+        var url = metadata.url + '/wfs/WfsDispatcher?';
+        var args = {
+          'typename' : metadata.name,
+          'version' : '1.0.0',
+          'service' : 'WFS',
+          'request' : 'GetFeature',
+          'outputFormat' : 'csv'
+        };
+
+        var params = [];
+        for (var key in args) {
+          params.push(key + '=' + encodeURIComponent(args[key]));
+        }
+
+        url += params.join('&');
+
+        window.open(url);
+      }
+    };
+
     this.getCSV = function() {
+      if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+        this.getCSV_Safari();
+        // return a fulfilled promise
+        var deferred = q_.defer();
+        deferred.resolve();
+        return deferred.promise;
+      }
+
       var metadata = this.selectedLayer.get('metadata');
       var postURL = metadata.url + '/wfs/WfsDispatcher';
       var layerName = metadata.name.replace(/:/g, '_');


### PR DESCRIPTION


## What does this PR do?

Safari does not properly support @download nor have
a workable alternative. Instead of downloading the table with
filters, the user is prompted that Safari does not support that
functionality and can download the entire table by clicking Ok.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/1282291/22953045/153be7e4-f2d5-11e6-9aa5-fbcb8416ca04.png)


### Related Issue

NODE-744
