### PR TITLE
Prevent truncation of ArcGIS Rest URLs.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -101,7 +101,9 @@
     // clean up any of the sources URLs
     for (var src_key in config.sources) {
         if (goog.isDefAndNotNull(config.sources[src_key].url)) {
-            config.sources[src_key].url = trimUrl(config.sources[src_key].url);
+            if (config.sources[src_key].ptype != 'gxp_arcrestsource') {
+                config.sources[src_key].url = trimUrl(config.sources[src_key].url);
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Most services do not work with a trailing "/" and various layers
require that this "/" be absent, however, this is not true for
ArcGIS Rest/tile layers.  This change prevents the trailing "/"
from being removed.

### Screenshot
N/A

### Related Issue

NODE-751