### PR TITLE
Added support for 4326 Preview Mapping.

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -139,7 +139,8 @@
              * @return {ol.geom.Polygon}
              */
             var extentToPolygon = function(extent) {
-              return ol.geom.Polygon.fromExtent(extent).transform('EPSG:4326', 'EPSG:3857');
+              // ensure the extent polygon is in the map's projection
+              return ol.geom.Polygon.fromExtent(extent).transform('EPSG:4326', mapService.getProjection());
             };
 
             /** When the preview map is moved it sets an extent in
@@ -636,6 +637,7 @@
             onResize();
 
             $(window).resize(onResize);
+
 
             /** This bit bootstraps the slider.
              *  XXX: This is another ugly jquery/angular hack.

--- a/src/index.html
+++ b/src/index.html
@@ -95,7 +95,8 @@
         registryEnabled: registryEnabled(),
         registryUrl: trimUrl("{{ REGISTRYURL }}"),
         nominatimSearchEnabled: nominatimSearchEnabled(),
-        unifiedLayerDialog: unifiedDialogEnabled()
+        unifiedLayerDialog: unifiedDialogEnabled(),
+        previewLayerConf: {{ MAP_PREVIEW_LAYER|safe }}
     };
     goog.object.extend( config, {{ config|safe }});
     // clean up any of the sources URLs


### PR DESCRIPTION
## What does this PR do?

- Preview map in 'Add Layers' modal now supports 4326 both
  as the base map projection and for displaying selection polygons.
- A new 'previewLayerConf' is available in the config that will
  allow for a non OSM tileset to be displayed - currently only
  ArcGIS Rest Tiles are supported.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/23290553/42dd4dca-fa17-11e6-80d6-a5b37d210609.png)

### Related Issue

NODE-755