### PR TITLE
Add support for Registry legend_url's.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -689,6 +689,13 @@ var SERVER_SERVICE_USE_PROXY = true;
         layerInfo.tile_url = cleanTileUrl(layerInfo.tile_url);
       }
 
+      // clean up legend url's as well.
+      if (layerInfo.legend_url) {
+        layerInfo.legend_url = cleanTileUrl(layerInfo.legend_url);
+      }
+
+      // add a legend url as available
+
       // likely, if the server is not defined then this
       //  is just from a registry search where there is no
       //  server definition.
@@ -714,6 +721,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         uuid: layerInfo.layer_identifier,
         CRS: ['EPSG:4326'],
         tile_url: layerInfo.tile_url,
+        legend_url: layerInfo.legend_url ? layerInfo.legend_url : null,
         detail_url: layerInfo.tile_url ? layerInfo.tile_url : null,
         author: author(layerInfo),
         domain: domain(layerInfo),

--- a/src/common/legend/partial/legend.tpl.html
+++ b/src/common/legend/partial/legend.tpl.html
@@ -11,7 +11,7 @@
                 <div class="legend-panel-title pull-left" id="legend-title-text" translate="legend_title"></div>
                 <i class="glyphicon glyphicon-remove legend-panel-title pull-right" ng-click="toggleLegend()"></i>
             </div>
-            <div class="panel in legend-panel-body" ng-repeat="layer in mapService.getLayers();">
+            <div class="panel in legend-panel-body" ng-repeat="layer in getLayers()">
                 <div class="panel-heading legend-item-header" data-toggle="collapse"
                     data-target="{{'#' + layer.get('metadata').uniqueID + 'legend'}}">{{layer.get('metadata').title}}
                 </div>


### PR DESCRIPTION
## What does this PR do?

Adds support for registry layers which have a legend_url
attribute.

- ServerService.js is updated to input, and clean, legend_urls
  and add them to the layer's config.
- LegendDirective has been updated with a custom filter for
  whether a layer should be displayed in the legend.
- The template for LegendDirective has been updated to use that
  function.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/23567448/df3418a2-001b-11e7-864c-8eae654a11b7.png)
_NOAA Now Coast, from Registry, Including Legend_

### Related Issue

NODE-530
