### PR TITLE
Add prompt and a spinner for the Unified Search Dialog.

### DIFF
--- a/src/app/locales/en.js
+++ b/src/app/locales/en.js
@@ -227,6 +227,8 @@
     'mgrs': 'MGRS',
     'other': 'Other',
     'search': 'Search',
+    'searching': 'Searching...',
+    'search_prompt': 'Please use any of the settings on the left to start a search.',
     'search_locations': 'Search Locations',
     'search_table': 'Search All Fields',
     'search_results': 'Search Results',

--- a/src/app/locales/es.js
+++ b/src/app/locales/es.js
@@ -230,6 +230,8 @@
     'mgrs': 'MGRS',
     'other': 'Otro',
     'search': 'Búsqueda',
+    'searching': 'Buscando...',
+    'search_prompt' : 'Por favor, utilice cualquiera de las opciones de la izquierda para iniciar una búsqueda.',
     'search_locations': 'Ubicaciones de Búsqueda',
     'search_table': 'Buscar Todos Los Campos',
     'search_results': 'Resultados de la Búsqueda',

--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -31,6 +31,15 @@
             scope.sortField = 'Title';
             scope.sortAscending = 'Ascending';
 
+            /** Track the overall progress of the searches.
+            *
+             *  States:
+             *   - 'no-search': A search has not been executed.
+             *   - 'started'  : A search has started.
+             *   - 'finished' : A serach has finished.
+             */
+            scope.searchState = 'no-search';
+
             /** List of owners. */
             scope.owners = [];
 
@@ -428,6 +437,10 @@
                 'exchange': [],
                 'registry': []
               };
+
+              // change the scope to finished, even if partially finished.
+              scope.searchState = 'finished';
+
               if (response.data && response.data.objects) {
                 // reset the current layers list for both servers.
                 servers.geoserver.layersConfig = [];
@@ -494,6 +507,9 @@
             scope.search = function() {
               // get the basic search parameters.
               var filter_options = scope.getSearchParams();
+
+              // indicate to the user that a search has started.
+              scope.searchState = 'started';
 
               // init the server configs as necessary.
               scope.configureServers();

--- a/src/common/addlayers/partials/unifiedLayerSearch.tpl.html
+++ b/src/common/addlayers/partials/unifiedLayerSearch.tpl.html
@@ -99,12 +99,23 @@
             </div> <!-- end of filters -->
 
             <div class="col-md-6 unified-split-view">
-                <div class="row" ng-hide="resultsCount > 0">
+                <div class="row" ng-show="searchState == 'no-search'">
+                    <div class="col-xs-12">
+                        <span loom-helpicon help=""></span> Please use any of the settings on the left to start a search.
+
+                    </div>
+                </div>
+                <div class="row" ng-show="searchState == 'started'">
+                    <div class="col-xs-12">
+                        <div class="loom-loading" text="{{ 'searching' | translate }}"></div>
+                    </div>
+                </div>
+                <div class="row" ng-show="searchState == 'finished' && resultsCount == 0">
                     <div class="col-xs-12">
                         <i>{{ 'search_no_results' | translate }}</i>
                     </div>
                 </div>
-                <div class="row" ng-show="resultsCount > 0">
+                <div class="row" ng-show="searchState == 'finished' && resultsCount > 0">
                     <div class="col-xs-8">
                         <div class="layers-count">
                           {{ pagingTitle }}

--- a/src/common/utils/LoadingDirective.js
+++ b/src/common/utils/LoadingDirective.js
@@ -7,6 +7,7 @@
           restrict: 'C',
           templateUrl: 'utils/partial/loading.tpl.html',
           scope: {
+            spinnerText: '@text',
             spinnerHidden: '='
           },
           link: function(scope, element, attrs) {
@@ -36,6 +37,16 @@
             var spinner = element.find('.spinner');
             spinner.css('width', scope.spinnerRadius + 'px');
             spinner.css('height', scope.spinnerRadius + 'px');
+
+            var text = element.find('.spinner-text');
+            // when the text exists, push it to the left to make it legible.
+            if (goog.isDefAndNotNull(scope.spinnerText) && scope.spinnerText.length > 0) {
+              text.css('padding-left', (scope.spinnerRadius + 2) + 'px');
+              text.css('padding-top', (scope.spinnerWidth) + 'px');
+            // else, don't waste the browser's time with rendering it.
+            } else {
+              text.css('display', 'none');
+            }
           }
         };
       });

--- a/src/common/utils/partial/loading.tpl.html
+++ b/src/common/utils/partial/loading.tpl.html
@@ -8,5 +8,8 @@
         <div class="loading-spinner"></div>
       </div>
     </div>
+    <div class="spinner-text">
+      {{ spinnerText }}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## What does this PR do?

The previous search dialog would show the user that they could
not find any layers, even before any search was executed. This caused
some confusion as one of the filters must be selected *before*
a search will execute.  This new version of the dialog attempts
to make that more clear by:
1. Showing a 'spinner' while the user is searching.
2. Adding first-time help test to the layers list in order to
   instruct the user to use the options at left to start a search.

This also includes a small update to the 'spinner' to allow it to be labeled. 

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/23625956/b7d9eee2-0270-11e7-8d6e-f6258be4012c.png)


### Related Issue

NODE-783