### PR TITLE
Fix for ArcGIS baselayer specification.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -1111,7 +1111,7 @@ var SERVER_SERVICE_USE_PROXY = true;
             var configMapLayers = configService_.configuration.map.layers;
             var lyrsCfg = [];
             // get gxp_arcsource server index
-            for (var i = 0; i < configSources.length; i++) {
+            for (var i in configSources) {
               if (configSources[i]['ptype'] === 'gxp_arcrestsource') {
                 esriIndex = i;
               }


### PR DESCRIPTION
## What does this PR do?
Sources end up described as an object and not an array,
so the loop was not able to find the ArcGIS source index. This fix
uses object key iteration instead of array iteration. To find the
correct source-id.


### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/23765575/41b25c78-04c7-11e7-97b4-2f6e8f48a5f9.png)


### Related Issue
