### PR TITLE
Fix Quirks with the BBOX Filter

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -239,7 +239,7 @@
                 case 'bbox':
                   scope.bbox = [];
                   scope.mapPreviewChangeCount = 0;
-                  // TOD0: set map to max extent
+                  scope.$emit('resetMap');
                   break;
                 case 'owner':
                   checkNone(scope.owners);

--- a/src/common/map/MapDirective.js
+++ b/src/common/map/MapDirective.js
@@ -82,10 +82,12 @@
             });
 
             $rootScope.$on('resetMap', function(event) {
-              var zoom = ol.animation.zoom({resolution: map.getView().getResolution()});
-              var pan = ol.animation.pan({source: map.getView().getCenter()});
-              map.beforeRender(pan, zoom);
-              map.getView().fit(firstExtent, map.getSize());
+              if (goog.isDefAndNotNull(map)) {
+                var zoom = ol.animation.zoom({resolution: map.getView().getResolution()});
+                var pan = ol.animation.pan({source: map.getView().getCenter()});
+                map.beforeRender(pan, zoom);
+                map.getView().fit(firstExtent, map.getSize());
+              }
             });
 
             scope.$watch('layers', function(layers) {

--- a/src/common/map/MapDirective.js
+++ b/src/common/map/MapDirective.js
@@ -35,11 +35,22 @@
               return null;
             };
 
+            // define the 'world' in extent
+            var world_bounds = [
+              -180, -85, 180, 85
+            ];
+
+            // get the map's projection, so the preview map matches.
+            var map_proj = configService.configuration.map.projection;
+            // transform the global extent to the map's projection.
+            var working_bounds = ol.proj.transformExtent(world_bounds, 'EPSG:4326', map_proj);
+
             var createMap = function() {
               map = new ol.Map({
                 target: scope.mapId,
                 view: new ol.View({
-                  projection: configService.configuration.map.projection,
+                  projection: map_proj,
+                  extent: working_bounds,
                   center: scope.center,
                   zoom: scope.zoom
                 }),


### PR DESCRIPTION
## What does this PR do?
1. Limits the user from panning to substantially out of bounds areas in the preview/filter map.

2. Previously the map did not reset when the user clicked
"Clear all", this now signals the map to reset and fixes a\
bug in which the map can be undefined

### Screenshot

### Related Issue

NODE-791

