### PR TITLE
Fix for Bing Maps API Key

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -1086,6 +1086,10 @@ var SERVER_SERVICE_USE_PROXY = true;
             {Title: 'BingCollinsBart', Name: 'CollinsBart', sourceParams: {imagerySet: 'collinsBart'}},
             {Title: 'BingSurvey', Name: 'Survey', sourceParams: {imagerySet: 'ordnanceSurvey'}}
           ];
+
+          for (var i = 0, ii = server.layersConfig.length; i < ii; i++) {
+            server.layersConfig[i].sourceParams.key = server.apiKey;
+          }
           deferredResponse.resolve(server);
         } else if (server.ptype === 'gxp_mapquestsource') {
           server.defaultServer = true;

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -695,7 +695,7 @@
         } else if (server.ptype === 'gxp_bingsource') {
 
           var sourceParams = {
-            key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3',
+            key: '',
             imagerySet: 'Aerial'
           };
 


### PR DESCRIPTION
## What does this PR do?
1. Removed the old key from the files.
2. Added the ability to parse the "apiKey" from the source
   definition and place it in the layerConfigs.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/23863853/d8ef870e-07de-11e7-82c9-414645fcaab2.png)


### Related Issue

NODE-796
