### PR TITLE
Created associations for 'undefined' commits.

### DIFF
--- a/src/common/diff/FeatureDiffService.js
+++ b/src/common/diff/FeatureDiffService.js
@@ -442,8 +442,10 @@
     this.performFeatureDiff = function(feature, newCommit, oldCommit, panel) {
       var diffOptions = new GeoGigFeatureDiffOptions();
       diffOptions.all = true;
-      diffOptions.newTreeish = newCommit;
-      diffOptions.oldTreeish = oldCommit;
+      // when new or old commits are null/undefined, use the shorthand
+      // for either the HEAD or the 0th point in the tree.
+      diffOptions.newTreeish = goog.isDefAndNotNull(newCommit) ? newCommit : 'HEAD';
+      diffOptions.oldTreeish = goog.isDefAndNotNull(oldCommit) ? oldCommit : '00000000';
       diffOptions.path = feature.id;
       panel.active = true;
       geogigService_.command(repoId_, 'featurediff', diffOptions).then(function(response) {


### PR DESCRIPTION
## What does this PR do?

1. The diff service was trying to call the Geogig service
   with 'undefined' as the newTreeish which was causing a failure.
2. To prevent that error (and others), the diff service will now
   check to ensure that newCommit and oldCommit are defined, and if not,
   substitute an appropriate reference to the start-or-end of the tree,
   (00000000 or HEAD).


### Screenshot

### Related Issue

NODE-690