### PR TITLE
Removed Feature Reprojection in Tableview

### DIFF
--- a/src/common/tableview/TableViewDirective.js
+++ b/src/common/tableview/TableViewDirective.js
@@ -214,16 +214,12 @@
             };
 
             scope.goToMap = function() {
-              var projectedgeom = transformGeometry(scope.selectedRow.feature.geometry,
-                  tableViewService.selectedLayer.get('metadata').projection,
-                  mapService.map.getView().getProjection());
-
-              mapService.zoomToExtent(projectedgeom.getExtent());
+              var geom = transformGeometry(scope.selectedRow.feature.geometry, null, null);
+              mapService.zoomToExtent(geom.getExtent());
 
               var item = {layer: tableViewService.selectedLayer, features: [scope.selectedRow.feature]};
               $('#table-view-window').modal('hide');
               featureManagerService.show(item);
-
             };
 
             scope.showHeatmap = function() {


### PR DESCRIPTION
## What does this PR do?

The geometries in the table were already in the map projection.
This change removes the 'double reprojection' which fixes the bad
extent being used for zooming to the feature on the map.

### Screenshot

### Related Issue

NODE-834
