### PR TITLE
Removed incoming feature reprojection for notifications.

### DIFF
--- a/src/common/updatenotification/UpdateNotificationDirective.js
+++ b/src/common/updatenotification/UpdateNotificationDirective.js
@@ -29,24 +29,8 @@
             //this function has to be defined outside of the loop, otherwise the linter gets angry
             var featureHandler = function(repoFeature) {
               var splitFeature = repoFeature.id.split('/');
-              var crs = goog.isDefAndNotNull(repoFeature.crs) ? repoFeature.crs : null;
-              mapService.map.getLayers().forEach(function(layer) {
-                var metadata = layer.get('metadata');
-                if (goog.isDefAndNotNull(metadata)) {
-                  if (goog.isDefAndNotNull(metadata.geogigStore) && metadata.geogigStore === repos[i].name) {
-                    if (goog.isDefAndNotNull(metadata.nativeName) && metadata.nativeName === splitFeature[0]) {
-                      if (goog.isDefAndNotNull(metadata.projection)) {
-                        crs = metadata.projection;
-                      }
-                    }
-                  }
-                }
-              });
-
               var geom = WKT.read(repoFeature.geometry[0]);
-              if (goog.isDefAndNotNull(crs)) {
-                geom.transform(crs, mapService.map.getView().getProjection());
-              }
+
               var feature = {
                 repo: repos[i].name,
                 layer: splitFeature[0],


### PR DESCRIPTION
## What does this PR do?
The zoom-to functionality reprojects features as necessary,
this change stops the notification parser from also projecting
the features on intake.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/1282291/24457096/c80055b2-145a-11e7-89e6-85a9c9b8432b.png)

### Related Issue
NODE-812
