### PR TITLE
Filter out non-layers from search.

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -457,7 +457,10 @@
                   if (goog.isDefAndNotNull(layer.registry_url)) {
                     index_name = 'registry';
                   }
-                  layers_by_index[index_name].push(layer);
+                  // ensure that maps and documents are excluded from the search results.
+                  if (index_name == 'registry' || layer.type_exact == 'layer') {
+                    layers_by_index[index_name].push(layer);
+                  }
                 }
 
                 // convert the results from the search using the appropriate


### PR DESCRIPTION
## What does this PR do?

After switching to the new integrated search functionality,
types other than layers were showing up in the add layers search.
This was causing MapLoom to attempt to add things to the map
that weren't layers.

### Screenshot

### Related Issue

NODE-774