### PR TITLE
Fix legend detection bug with heatmaps.

### DIFF
--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -66,7 +66,8 @@
               }
 
               // ignore background layers, such as OSM.
-              if (layer.get('metadata').config.group == 'background') {
+              var conf = layer.get('metadata').config;
+              if (conf && conf.group == 'background') {
                 return false;
               }
 


### PR DESCRIPTION
## What does this PR do?
Heatmaps were creating a new layer without a 'config' in the metadata,
a situation which the legend was not prepared to handle.  Now the
Legend will check to ensure config is defined before trying to examine
it.

### Screenshot

![image](https://cloud.githubusercontent.com/assets/1282291/24769044/9a49bdcc-1aca-11e7-9103-e9ba194bc531.png)

### Related Issue

NODE-854