### PR TITLE
Removed erroneous addModify.

### DIFF
--- a/src/common/featuremanager/FeatureManagerService.js
+++ b/src/common/featuremanager/FeatureManagerService.js
@@ -80,7 +80,7 @@
           exclusiveModeService_.addMode = false;
           mapService_.removeDraw();
           mapService_.addSelect();
-          mapService_.addModify();
+          //mapService_.addModify();
           mapService_.selectFeature(event.feature);
         }
       });


### PR DESCRIPTION
## What does this PR do?

Adding the modify interaction while adding a feature was causing
event clash with drawing.  This error was handled differently
across browsers.

Tested with IE11, Chrome 57, FF (latest).

### Screenshot

N/A

### Related Issue

NODE-862
