### PR TITLE
Utilize GeoQuery data within MapLoom search

### DIFF
--- a/src/common/search/SearchDirective.js
+++ b/src/common/search/SearchDirective.js
@@ -2,13 +2,12 @@
   var module = angular.module('loom_search_directive', []);
 
   module.directive('loomSearch',
-      function($timeout, $translate, searchService, dialogService, mapService, configService) {
+      function($rootScope, $timeout, $translate, searchService, dialogService, mapService, configService) {
         return {
-          restrict: 'C',
           replace: true,
           templateUrl: 'search/partial/search.tpl.html',
           // The linking function will add behavior to the template
-          link: function(scope) {
+          link: function(scope, element) {
             scope.searchQuery = '';
             scope.searchInProgress = false;
             scope.searchResults = [];
@@ -88,7 +87,7 @@
             };
 
             scope.isExpanded = function(id) {
-              return $(id).attr('class') == 'in';
+              return $(id).hasClass('in');
             };
           }
         };

--- a/src/common/search/SearchDirective.js
+++ b/src/common/search/SearchDirective.js
@@ -2,7 +2,7 @@
   var module = angular.module('loom_search_directive', []);
 
   module.directive('loomSearch',
-      function($timeout, $translate, searchService, dialogService, mapService) {
+      function($timeout, $translate, searchService, dialogService, mapService, configService) {
         return {
           restrict: 'C',
           replace: true,
@@ -42,6 +42,7 @@
             };
 
             scope.performSearch = function() {
+              scope.config = configService.configuration;
               if (scope.displayingResults()) {
                 scope.searchQuery = '';
                 scope.clearResults();
@@ -84,6 +85,10 @@
 
             scope.resultClicked = function(result) {
               zoomToResult(result);
+            };
+
+            scope.isExpanded = function(id) {
+              return $(id).attr('class') == 'in';
             };
           }
         };

--- a/src/common/search/SearchDirective.spec.js
+++ b/src/common/search/SearchDirective.spec.js
@@ -1,0 +1,25 @@
+describe('SearchDirective', function() {
+  var element, scope, compiledElement, configService, searchService;
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_search'));
+  beforeEach(module('search/partial/search.tpl.html'));
+
+  beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_) {
+    scope = $rootScope.$new();
+    element = angular.element('<div loom-search></div>');
+    compiledElement = $compile(element)(scope);
+    scope.$digest();
+    configService = _configService_;
+  }));
+
+  describe('isExpanded', function() {
+    it('checks if a DOM element is expanded', function() {
+      var mock_expanded = $("<div>", {"class": "in cool"});
+      var mock_collapsed = $("<div>", {"class": "collapsed"});
+      // Why does it think the scope is undefined?
+      console.info(compiledElement.scope());
+      expect(compiledElement.scope().isExpanded(mock_expanded)).toBe(true);
+      expect(compiledElement.scope().isExpanded(mock_collapsed)).toBe(false);
+    });
+  });
+});

--- a/src/common/search/SearchDirective.spec.js
+++ b/src/common/search/SearchDirective.spec.js
@@ -4,22 +4,42 @@ describe('SearchDirective', function() {
   beforeEach(module('loom_search'));
   beforeEach(module('search/partial/search.tpl.html'));
 
-  beforeEach(inject(function($rootScope, $compile, $templateCache, _configService_) {
+  beforeEach(inject(function($rootScope, $compile, _configService_) {
     scope = $rootScope.$new();
-    element = angular.element('<div loom-search></div>');
+    element = angular.element('<div><div class="loom-search"></div></div>');
     compiledElement = $compile(element)(scope);
     scope.$digest();
     configService = _configService_;
   }));
 
   describe('isExpanded', function() {
-    it('checks if a DOM element is expanded', function() {
-      var mock_expanded = $("<div>", {"class": "in cool"});
-      var mock_collapsed = $("<div>", {"class": "collapsed"});
-      // Why does it think the scope is undefined?
-      console.info(compiledElement.scope());
-      expect(compiledElement.scope().isExpanded(mock_expanded)).toBe(true);
-      expect(compiledElement.scope().isExpanded(mock_collapsed)).toBe(false);
+    it('checks if this result should be expanded', function() {
+      element.scope().searchResults[0] = {};
+      // should still work if it doesn't have the member and return false
+      expect(element.scope().isExpanded(element.scope().searchResults[0])).toBe(false);
+      // member becomes false after first toggle
+      element.scope().toggleOpen(element.scope().searchResults[0]);
+      expect(element.scope().isExpanded(element.scope().searchResults[0])).toBe(false);
+      // member becomes true after second toggle
+      element.scope().toggleOpen(element.scope().searchResults[0]);
+      expect(element.scope().isExpanded(element.scope().searchResults[0])).toBe(true);
+    });
+  });
+
+  describe('searchExpand / collapse', function() {
+    it('should modify div element to collapse or expand when searchExpanded is toggled', function() {
+      // should default to false / collapsed
+      expect(element.scope().searchExpanded).toBe(false);
+      expect(element.scope().getClassSearchExpanded()).toBe('collapse');
+
+      element.scope().searchExpanded = true;
+      expect(element.scope().searchExpanded).toBe(true);
+      expect(element.scope().getClassSearchExpanded()).toBe('in');
+
+      element.scope().searchExpanded = false;
+      expect(element.scope().searchExpanded).toBe(false);
+      expect(element.scope().getClassSearchExpanded()).toBe('collapse');
     });
   });
 });
+

--- a/src/common/search/SearchService.js
+++ b/src/common/search/SearchService.js
@@ -6,6 +6,7 @@
   var configService_ = null;
   var mapService_ = null;
   var searchlayer_ = null;
+  var service_ = null;
 
   module.provider('searchService', function() {
     this.$get = function($rootScope, $http, $q, $translate, configService, mapService) {
@@ -13,6 +14,7 @@
       q_ = $q;
       configService_ = configService;
       mapService_ = mapService;
+      service_ = this;
 
       searchlayer_ = new ol.layer.Vector({
         metadata: {
@@ -46,7 +48,7 @@
 
     // algorithm taken from http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates#Java
     // from the "Boundingcoordinates" method
-    convertLatLonToBbox = function(coordinates) {
+    this.convertLatLonToBbox = function(coordinates) {
       // This is the distance in km of the radius of the "greater circle"
       // that is, distance to an imagined point at the edge of our view
       // unit is in km
@@ -165,7 +167,7 @@
             forEachArrayish(response.data.features, function(result) {
               results.push({
                 location: [parseFloat(result.geometry.coordinates[0]), parseFloat(result.geometry.coordinates[1])],
-                boundingbox: convertLatLonToBbox(result.geometry.coordinates),
+                boundingbox: service_.convertLatLonToBbox(result.geometry.coordinates),
                 name: result.properties.name,
                 cc: result.properties.cc,
                 source: result.properties.source,

--- a/src/common/search/SearchService.js
+++ b/src/common/search/SearchService.js
@@ -166,8 +166,11 @@
               results.push({
                 location: [parseFloat(result.geometry.coordinates[0]), parseFloat(result.geometry.coordinates[1])],
                 boundingbox: convertLatLonToBbox(result.geometry.coordinates),
-                // In the future we want to add another property and have it pull right and be smaller text
-                name: result.properties.name + '(' + result.properties.featureDesignationName + ')'
+                name: result.properties.name,
+                cc: result.properties.cc,
+                source: result.properties.source,
+                featureDesignationName: result.properties.featureDesignationName,
+                featureDesignationCode: result.properties.featureDesignationCode
               });
             });
             promise.resolve(results);

--- a/src/common/search/SearchService.spec.js
+++ b/src/common/search/SearchService.spec.js
@@ -1,0 +1,21 @@
+describe('search/SearchService', function() {
+  var searchService;
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_search'));
+
+  beforeEach(inject(function(_searchService_) {
+    searchService = _searchService_;
+  }));
+
+  describe('convertLatLonToBbox', function() {
+    var mock_coordinates = [-88.433333, 17.983333];
+    it('converts coordinates to a 2KM EPSG:4326 boundingbox', function() {
+      bbox = searchService.convertLatLonToBbox(mock_coordinates);
+      // The coordinates should be less than 1 difference to the bbox values
+      expect(bbox[0]).toBeCloseTo(mock_coordinates[1], 0);
+      expect(bbox[1]).toBeCloseTo(mock_coordinates[1], 0);
+      expect(bbox[2]).toBeCloseTo(mock_coordinates[0], 0);
+      expect(bbox[3]).toBeCloseTo(mock_coordinates[0], 0);
+    });
+  });
+});

--- a/src/common/search/SearchService.spec.js
+++ b/src/common/search/SearchService.spec.js
@@ -1,21 +1,84 @@
 describe('search/SearchService', function() {
-  var searchService;
+  var searchService, mapService;
   beforeEach(module('MapLoom'));
   beforeEach(module('loom_search'));
 
-  beforeEach(inject(function(_searchService_) {
+  beforeEach(inject(function(_searchService_, _mapService_) {
     searchService = _searchService_;
+    mapService = _mapService_;
   }));
 
   describe('convertLatLonToBbox', function() {
     var mock_coordinates = [-88.433333, 17.983333];
     it('converts coordinates to a 2KM EPSG:4326 boundingbox', function() {
       bbox = searchService.convertLatLonToBbox(mock_coordinates);
-      // The coordinates should be less than 1 difference to the bbox values
+      // the coordinates should be less than 1 difference to the bbox values
       expect(bbox[0]).toBeCloseTo(mock_coordinates[1], 0);
       expect(bbox[1]).toBeCloseTo(mock_coordinates[1], 0);
       expect(bbox[2]).toBeCloseTo(mock_coordinates[0], 0);
       expect(bbox[3]).toBeCloseTo(mock_coordinates[0], 0);
+    });
+  });
+
+  describe('populateSearchLayer', function() {
+    it('should populate the map with search results layer', function() {
+      // make mock results and call populate
+      var mock_results = [{
+        location: [-0.1276473, 51.5073219],
+        boundingbox: [51.2867602, 51.6918741, -0.510375, 0.3340155],
+        name: 'London'
+      }];
+      // the only thing we can really compare is the location
+      var feature_location = ol.proj.transform(
+        mock_results[0].location, 'EPSG:4326', mapService.map.getView().getProjection()
+      );
+      searchService.populateSearchLayer(mock_results);
+      // make sure the location matches after populating it
+      expect(feature_location).toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+      // replace with a new search layer
+      mock_results = [{
+        location: [-81.2466429, 42.988576],
+        boundingbox: [42.828576, 43.148576, -81.4066429, -81.0866429],
+        name: 'notLondon'
+      }];
+      feature_location = ol.proj.transform(
+        mock_results[0].location, 'EPSG:4326', mapService.map.getView().getProjection()
+      );
+      // make sure before populating it doesn't match
+      expect(feature_location).not.toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+      // make sure the location matches after populating it
+      searchService.populateSearchLayer(mock_results);
+      expect(feature_location).toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+    });
+  });
+
+  describe('clearSearchLayer', function() {
+    it('should remove the search results layer from the map', function() {
+      // make mock results and call populate
+      var mock_results = [{
+        location: [-0.1276473, 51.5073219],
+        boundingbox: [51.2867602, 51.6918741, -0.510375, 0.3340155],
+        name: 'London'
+      }];
+      // the only thing we can really compare is the location
+      var feature_location = ol.proj.transform(
+        mock_results[0].location, 'EPSG:4326', mapService.map.getView().getProjection()
+      );
+      searchService.populateSearchLayer(mock_results);
+      // make sure the location matches after populating it
+      expect(feature_location).toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+      expect(mapService.map.getLayers().getLength()).toBe(1);
+      searchService.clearSearchLayer();
+      // mapService should be empty after cleared
+      expect(mapService.map.getLayers().getLength()).toBe(0);
     });
   });
 });

--- a/src/common/search/partial/search.tpl.html
+++ b/src/common/search/partial/search.tpl.html
@@ -16,7 +16,7 @@
       </form>
     </em>
   </div>
-  <div id="search-results-panel" class="search-content panel-collapse collapse">
+  <div id="search-results-panel" class="search-content panel-collapse" ng-class="getClassSearchExpanded">
     <div id="search-collapse-group" class="panel-group">
       <ul class="list-group" ng-if="config.nominatimSearchEnabled">
         <li class="list-group-item" ng-click="resultClicked(result)"
@@ -28,8 +28,8 @@
         <li class="list-group-item" ng-click="resultClicked(result)"
             ng-repeat="result in searchResults" tooltip-popup-delay="500" tooltip-placement="right" tooltip-append-to-body="true" tooltip="{{result.name}}">
           <div ng-if="result.classification">
-            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}</span><button data-toggle="collapse" data-target="#midb{{$index}}" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded('#midb' + $index)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded('#midb' + $index)"></i></button>
-            <div id="midb{{$index}}" class="collapse">
+            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}</span><button ng-click="toggleOpen(result)" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded(result)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded(result)"></i></button>
+            <div ng-class="isExpanded(result)">
               <span><b>Source</b>: {{result.source}}</span><br>
               <span><b>CC</b>: {{result.cc}}</span><br>
               <span><b>Record Status</b>: {{result.record_status}}</span><br>
@@ -39,8 +39,8 @@
             </div>
           </div>
           <div ng-if="result.featureDesignationCode">
-            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}, {{result.cc}}</span><button data-toggle="collapse" data-target="#details{{$index}}" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded('#midb' + $index)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded('#midb' + $index)"></i></button>
-            <div id="details{{$index}}" class="collapse">
+            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}, {{result.cc}}</span><button ng-click="toggleOpen(result)" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded(result)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded(result)"></i></button>
+            <div ng-class="isExpanded(result)">
               <span><b>Source</b>: {{result.source}}</span><br>
               <span><b>CC</b>: {{result.cc}}</span><br>
               <span><b>Feature Designation Name</b>: {{result.featureDesignationName}} ({{result.featureDesignationCode}})</span>

--- a/src/common/search/partial/search.tpl.html
+++ b/src/common/search/partial/search.tpl.html
@@ -18,10 +18,34 @@
   </div>
   <div id="search-results-panel" class="search-content panel-collapse collapse">
     <div id="search-collapse-group" class="panel-group">
-      <ul class="list-group">
+      <ul class="list-group" ng-if="config.nominatimSearchEnabled">
         <li class="list-group-item" ng-click="resultClicked(result)"
             ng-repeat="result in searchResults" tooltip-popup-delay="500" tooltip-placement="right" tooltip-append-to-body="true" tooltip="{{result.name}}">
           <span class="ellipsis search-result-name">{{result.name}}</span>
+        </li>
+      </ul>
+      <ul class="list-group" ng-if="config.geoquerySearchEnabled">
+        <li class="list-group-item" ng-click="resultClicked(result)"
+            ng-repeat="result in searchResults" tooltip-popup-delay="500" tooltip-placement="right" tooltip-append-to-body="true" tooltip="{{result.name}}">
+          <div ng-if="result.classification">
+            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}</span><button data-toggle="collapse" data-target="#midb{{$index}}" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded('#midb' + $index)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded('#midb' + $index)"></i></button>
+            <div id="midb{{$index}}" class="collapse">
+              <span><b>Source</b>: {{result.source}}</span><br>
+              <span><b>CC</b>: {{result.cc}}</span><br>
+              <span><b>Record Status</b>: {{result.record_status}}</span><br>
+              <span><b>Classification</b>: {{result.classification}}</span><br>
+              <span><b>BE</b>: {{result.be}}</span><br>
+              <span><b>Suffix</b>: {{result.suffix}}</span>
+            </div>
+          </div>
+          <div ng-if="result.featureDesignationCode">
+            <span class="ellipsis search-result-name" style="width: 85%">{{result.name}}, {{result.cc}}</span><button data-toggle="collapse" data-target="#details{{$index}}" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-chevron-down" ng-if="!isExpanded('#midb' + $index)"></i><i class="glyphicon glyphicon-chevron-up" ng-if="isExpanded('#midb' + $index)"></i></button>
+            <div id="details{{$index}}" class="collapse">
+              <span><b>Source</b>: {{result.source}}</span><br>
+              <span><b>CC</b>: {{result.cc}}</span><br>
+              <span><b>Feature Designation Name</b>: {{result.featureDesignationName}} ({{result.featureDesignationCode}})</span>
+            </div>
+          </div>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## What does this PR do?
Extends the use of GeoQuery integration through reported data in the search bar. By default shows just the name or name and country code, but the search panel is expandable to view additional data.

### Screenshot
Search query:
![image](http://i.imgur.com/yQjZwCj.png)

Expanded data:
![image](http://i.imgur.com/AW3Gief.png)

### Related Issue
N/A