### PR TITLE
Added z-index directive to popup css.

### DIFF
--- a/src/common/featuremanager/style/featuremanager.less
+++ b/src/common/featuremanager/style/featuremanager.less
@@ -11,6 +11,10 @@
   white-space:nowrap;
   text-overflow: ellipsis;
   min-width: 250px;
+
+  /* ensure that the popup box comes on top of the legend */
+  z-index: 1000;
+
   &:after, &:before {
     top: 100%;
     border: solid transparent;


### PR DESCRIPTION
## What does this PR do?

The box was getting buried as the z-level layout was
no specified.  Putting on a sufficiently high z-level
has allowed the popup box to float to the top.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/1282291/25713879/d2d9f36c-30bb-11e7-9f5f-697898649ecf.png)

### Related Issue

NODE-304