### PR TITLE
Forgotten null metadata check.

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -478,7 +478,7 @@
 
       this.map.getLayers().forEach(function(layer) {
         var searchLayer = false;
-        if (layer.get('metadata').internalLayer) {
+        if (goog.isDefAndNotNull(layer.get('metadata')) && layer.get('metadata').internalLayer) {
           if (layer.get('metadata').searchLayer || layer.get('metadata').searchResults) {
             searchLayer = true;
           }


### PR DESCRIPTION
## What does this PR do?
Sometimes metadata comes back as null/undef'd on dynamic layers,
the new search stuff was not checking for it.

### Screenshot
N/A

### Related Issue

NODE-904
