### PR TITLE
Correctly handle a GeoQuery search that returns results from MIDB sou…

### DIFF
--- a/src/common/search/SearchService.js
+++ b/src/common/search/SearchService.js
@@ -166,15 +166,29 @@
           if (goog.isDefAndNotNull(response.data.features) && goog.isArray(response.data.features)) {
             var results = [];
             forEachArrayish(response.data.features, function(result) {
-              results.push({
-                location: [parseFloat(result.geometry.coordinates[0]), parseFloat(result.geometry.coordinates[1])],
-                boundingbox: service_.convertLatLonToBbox(result.geometry.coordinates),
-                name: result.properties.name,
-                cc: result.properties.cc,
-                source: result.properties.source,
-                featureDesignationName: result.properties.featureDesignationName,
-                featureDesignationCode: result.properties.featureDesignationCode
-              });
+              if (result.properties.featureDesignationCode) {
+                results.push({
+                  location: [parseFloat(result.geometry.coordinates[0]), parseFloat(result.geometry.coordinates[1])],
+                  boundingbox: service_.convertLatLonToBbox(result.geometry.coordinates),
+                  name: result.properties.name,
+                  cc: result.properties.cc,
+                  source: result.properties.source,
+                  featureDesignationName: result.properties.featureDesignationName,
+                  featureDesignationCode: result.properties.featureDesignationCode
+                });
+              } else if (result.properties.classification) {
+                results.push({
+                  location: [parseFloat(result.geometry.coordinates[0]), parseFloat(result.geometry.coordinates[1])],
+                  boundingbox: service_.convertLatLonToBbox(result.geometry.coordinates),
+                  name: result.properties.name,
+                  cc: result.properties.cc,
+                  source: result.properties.source,
+                  record_status: result.properties.record_status,
+                  classification: result.properties.classification,
+                  be: result.properties.be,
+                  suffix: result.properties.suffix
+                });
+              }
             });
             promise.resolve(results);
           } else {
@@ -228,14 +242,14 @@
       searchlayer_.getSource().clear();
       mapService_.map.removeLayer(searchlayer_);
       mapService_.map.addLayer(searchlayer_);
-      forEachArrayish(results, function(result) {
+      forEachArrayish(results, function(result, index) {
         var olFeature = new ol.Feature();
         // properly assign feature data (removing hashkey metadata)
         olFeature.properties = angular.copy(result);
         if (result.name.length > 25) {
-          olFeature.setId(result.name.substring(0, 25) + '...');
+          olFeature.setId(result.name.substring(0, 25) + '...' + index);
         } else {
-          olFeature.setId(result.name);
+          olFeature.setId(result.name + index);
         }
         olFeature.setGeometry(new ol.geom.Point(ol.proj.transform(result.location, 'EPSG:4326',
             mapService_.map.getView().getProjection())));

--- a/src/common/search/SearchService.spec.js
+++ b/src/common/search/SearchService.spec.js
@@ -28,7 +28,6 @@ describe('search/SearchService', function() {
         boundingbox: [51.2867602, 51.6918741, -0.510375, 0.3340155],
         name: 'London'
       }];
-      // the only thing we can really compare is the location
       var feature_location = ol.proj.transform(
         mock_results[0].location, 'EPSG:4326', mapService.map.getView().getProjection()
       );
@@ -36,6 +35,10 @@ describe('search/SearchService', function() {
       // make sure the location matches after populating it
       expect(feature_location).toEqual(
         mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+      // make sure the ID is the name + index
+      expect('London0').toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getId()
       );
       // replace with a new search layer
       mock_results = [{
@@ -54,6 +57,10 @@ describe('search/SearchService', function() {
       searchService.populateSearchLayer(mock_results);
       expect(feature_location).toEqual(
         mapService.map.getLayers().item(0).getSource().getFeatures()[0].getGeometry().getCoordinates()
+      );
+      // make sure the ID is the name + index
+      expect('notLondon0').toEqual(
+        mapService.map.getLayers().item(0).getSource().getFeatures()[0].getId()
       );
     });
   });


### PR DESCRIPTION
…rces

## What does this PR do?
Allows searchService to correctly handle results from a GeoQuery search if the source is MIDB (gives different data from other GeoQuery sources).

### Screenshot
N/A

### Related Issue
[NODE-917](https://issues.boundlessgeo.com:8443/browse/NODE-917)