### PR TITLE
Utilize a layer's name property if it exists

### DIFF
--- a/src/common/layers/partials/layers.tpl.html
+++ b/src/common/layers/partials/layers.tpl.html
@@ -7,7 +7,7 @@
          data-parent="#layerpanel-group" data-target="#{{layer.get('metadata').uniqueID}}">
       <div class="row">
         <div class="layer-title ellipsis" ng-class="{'placeholder-layer-title': layer.get('metadata').placeholder}">
-          <i ng-show="isGeogig(layer)" class="fa fa-code-fork"></i>&nbsp;{{layer.get('metadata').title}}
+          <i ng-show="isGeogig(layer)" class="fa fa-code-fork"></i>&nbsp;{{layer.get('metadata').name ? layer.get('metadata').name : layer.get('metadata').title}}
         </div>
         <div class="layer-buttons">
           <span ng-click="featureManagerService.startFeatureInsert(layer)" tooltip-append-to-body="true"


### PR DESCRIPTION
## What does this PR do?
In the sidebar, use a layer's `name` property if it exists. If it doesn't, defaults to `title`

### Screenshot
![image](http://i.imgur.com/aZJcQsw.png)

### Related Issue
[NODE-1036](https://issues.boundlessgeo.com:8443/browse/NODE-1036)