### PR TITLE
Using exchange attribute options in the appropriate views.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "bootstrap-filestyl": "git://github.com/markusslima/bootstrap-filestyle.git#1.2.1",
     "angularjs-slider": "~2.13.0",
     "components-font-awesome": "4.6.3",
-    "angular-file-saver": "1.0.1"
+    "angular-file-saver": "1.0.1",
+    "lodash": "4.17.4"
   }
 }

--- a/build.config.js
+++ b/build.config.js
@@ -99,7 +99,8 @@ module.exports = {
 
       'vendor/bootstrap-sortable/Scripts/bootstrap-sortable.js',
       'vendor/angular-xeditable/dist/js/xeditable.min.js',
-      'vendor/angularjs-slider/dist/rzslider.min.js'
+      'vendor/angularjs-slider/dist/rzslider.min.js',
+      'vendor/lodash/dist/lodash.min.js'
     ],
     css: [
       'vendor/ol3/ol.css',

--- a/src/common/diff/FeaturePanelDirective.js
+++ b/src/common/diff/FeaturePanelDirective.js
@@ -114,10 +114,18 @@
                   break;
               }
 
-              if (featureDiffService.schema[property.attributename]._nillable === 'false' &&
-                  (property[key] === '' || property[key] === null)) {
+              if (scope.isAttributeRequired(property.attributename) &&
+                  (property[key] === '' || _is.Nil(property[key]))) {
                 property.valid = false;
               }
+            };
+
+            scope.isAttributeRequired = function(property) {
+              var exchangeMetadataAttribute = getExchangeMetadataAttribute(property);
+              var schema = featureDiffService.schema;
+
+              return (!_.isNil(schema) && schema.hasOwnProperty(property) && schema[property].nillable === 'false') ||
+                  (!_.isNil(exchangeMetadataAttribute) && exchangeMetadataAttribute.required);
             };
 
             scope.$on('feature-diff-performed', updateVariables);
@@ -128,6 +136,44 @@
             scope.$on('hide-authors', function() {
               scope.authorsShown = false;
             });
+
+            scope.isAttributeVisible = function(property) {
+              var schema = featureDiffService.layer.get('metadata').schema;
+
+              // if there is no schema, show the attribute. only filter out if there is schema and attr is set to hidden
+              if (!goog.isDefAndNotNull(schema) || !schema.hasOwnProperty(property)) {
+                return true;
+              }
+
+              return schema[property].visible;
+            };
+
+            scope.getAttributeLabel = function(property) {
+              var exchangeMetadataAttribute = getExchangeMetadataAttribute(property);
+
+              if (goog.isDefAndNotNull(exchangeMetadataAttribute) &&
+                  goog.isDefAndNotNull(exchangeMetadataAttribute.attribute_label) &&
+                  exchangeMetadataAttribute.attribute_label.length > 0) {
+                return exchangeMetadataAttribute.attribute_label;
+              }
+
+              return property;
+            };
+
+            function getExchangeMetadataAttribute(property) {
+              var exchangeMetadata = featureDiffService.layer.get('exchangeMetadata');
+
+              if (!_.isNil(exchangeMetadata) && !_.isNil(exchangeMetadata.attributes)) {
+                for (var index in exchangeMetadata.attributes) {
+                  if (!_.isNil(exchangeMetadata.attributes[index]) &&
+                      exchangeMetadata.attributes[index].attribute === property) {
+                    return exchangeMetadata.attributes[index];
+                  }
+                }
+              }
+
+              return null;
+            }
           }
         };
       }

--- a/src/common/diff/partial/featurepanel.tpl.html
+++ b/src/common/diff/partial/featurepanel.tpl.html
@@ -52,27 +52,20 @@
                                 seperate-time="false" date-object="attribute" date="false"></datetimepicker>
               </div>
               -->
-              <div ng-switch-when="simpleType" class="merge-select" ng-class="{'input-group': attribute.editable, 'has-error': !attribute.valid}">
-                <div ng-if="attribute.editable" class="input-group-btn">
-                  <button ng-disabled="!isConflictPanel" type="button" class="btn btn-default dropdown-toggle attr-none"
-                          data-toggle="dropdown">
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li>
-                      <a ng-click="selectValue(attribute, null)">&nbsp;</a>
-                    </li>
-                    <li ng-repeat="enum in attribute.enum">
-                      <a ng-click="selectValue(attribute, $index)">{{enum._value}}</a>
-                    </li>
-                  </ul>
-                </div>
-                <input ng-model="attribute.newvalue" type="text" class="form-control attr-none" disabled ng-class="{
-                      'attr-added': attribute.changetype == 'ADDED',
-                      'attr-modified': attribute.changetype == 'MODIFIED',
-                      'attr-removed' : attribute.changetype == 'REMOVED' || panel.geometry.changetype == 'REMOVED',
-                      'form-control' : attribute.editable
-                    }"/>
+              <div ng-switch-when="simpleType" class="merge-select" ng-class="{'has-error': !attribute.valid}">
+                <select ng-model="attribute.newvalue"
+                  ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in attribute.enum"
+                  ng-change="validateField(attribute, 'newvalue')"
+                  ng-disabled="!attribute.editable || !isConflictPanel"
+                  class="form-control attr-none"
+                  ng-class="{
+                    'attr-added': attribute.changetype == 'ADDED',
+                    'attr-modified': attribute.changetype == 'MODIFIED',
+                    'attr-removed' : attribute.changetype == 'REMOVED' || panel.geometry.changetype == 'REMOVED',
+                    'form-control' : attribute.editable
+                  }">
+                  <option></option>
+                </select>
               </div>
               <div ng-switch-when="xsd:boolean" class="merge-select" ng-class="{'input-group': attribute.editable, 'has-error': !attribute.valid}">
                 <div ng-if="attribute.editable" class="input-group-btn">

--- a/src/common/diff/style/diff.less
+++ b/src/common/diff/style/diff.less
@@ -168,7 +168,7 @@
         border: 1px solid darken(@featurePanelColor, 10%);
       }
 
-      input.attr-none {
+      input.attr-none, select.attr-none {
         width: 98%;
         background-color: @featurePanelColor;
         border: 1px solid darken(@featurePanelColor, 10%);
@@ -179,17 +179,17 @@
         }
       }
 
-      input.attr-modified {
+      input.attr-modified, select.attr-modified {
         background-color: @modifiedAttributeColor;
         border: 1px solid darken(@modifiedAttributeColor, 15%);
       }
 
-      input.attr-added {
+      input.attr-added, select.attr-added {
         background-color: @addedAttributeColor;
         border: 1px solid darken(@addedAttributeColor, 10%);
       }
 
-      input.attr-removed {
+      input.attr-removed, select.attr-removed {
         background-color: @removedAttributeColor;
         border: 1px solid darken(@removedAttributeColor, 10%);
       }

--- a/src/common/featuremanager/FeatureInfoBoxDirective.js
+++ b/src/common/featuremanager/FeatureInfoBoxDirective.js
@@ -56,6 +56,47 @@
               return schema[property].visible;
             };
 
+            scope.getAttributeLabel = function(property) {
+              var exchangeMetadataAttribute = getExchangeMetadataAttribute(property);
+
+              if (goog.isDefAndNotNull(exchangeMetadataAttribute) &&
+                  goog.isDefAndNotNull(exchangeMetadataAttribute.attribute_label) &&
+                  exchangeMetadataAttribute.attribute_label.length > 0) {
+                return exchangeMetadataAttribute.attribute_label;
+              }
+
+              return property;
+            };
+
+            function getExchangeMetadataAttribute(property) {
+              var exchangeMetadata = featureManagerService.getSelectedLayer().get('exchangeMetadata');
+
+              if (goog.isDefAndNotNull(exchangeMetadata) && goog.isDefAndNotNull(exchangeMetadata.attributes)) {
+                for (var index in exchangeMetadata.attributes) {
+                  if (goog.isDefAndNotNull(exchangeMetadata.attributes[index]) &&
+                      exchangeMetadata.attributes[index].attribute === property) {
+                    return exchangeMetadata.attributes[index];
+                  }
+                }
+              }
+
+              return null;
+            }
+
+            scope.getAttributeValue = function(property, value) {
+              var exchangeMetadataAttribute = getExchangeMetadataAttribute(property);
+
+              if (!_.isNil(exchangeMetadataAttribute) &&
+                  !_.isNil(exchangeMetadataAttribute.options) &&
+                  !_.isEmpty(exchangeMetadataAttribute.options)) {
+                var option = _.find(exchangeMetadataAttribute.options, { value: value });
+                if (option && option.label) {
+                  return option.value + ' - ' + option.label;
+                }
+              }
+
+              return value;
+            };
 
             scope.showFeatureHistory = function() {
               if (!scope.loadingHistory) {
@@ -135,73 +176,6 @@
                 mapService.addToSpatialFilterLayer(feature);
                 featureManagerService.hide();
               }
-            };
-
-            scope.pinFeature = function() {
-              var searchResults;
-              mapService.map.getLayers().forEach(function(layer) {
-                if (layer.get('metadata').searchResults) {
-                  searchResults = layer;
-                }
-              });
-              // create pinned features layer if it does not exist yet
-              if (!goog.isDefAndNotNull(searchResults)) {
-                searchResults = new ol.layer.Vector({
-                  metadata: {
-                    title: $translate.instant('pinned_search'),
-                    internalLayer: true,
-                    searchResults: true
-                  },
-                  source: new ol.source.Vector({
-                    parser: null
-                  }),
-                  style: function(feature, resolution) {
-                    return [new ol.style.Style({
-                      image: new ol.style.Circle({
-                        radius: 8,
-                        fill: new ol.style.Fill({
-                          color: '#FF0000'
-                        }),
-                        stroke: new ol.style.Stroke({
-                          color: '#000000'
-                        })
-                      })
-                    })];
-                  }
-                });
-                // add the search results to the map
-                mapService.map.addLayer(searchResults);
-              }
-              // add a clone of the selected feature to the pinned search result
-              var olFeature =
-                  featureManagerService.getSelectedLayer().getSource().getFeatureById(
-                      featureManagerService.getSelectedItem().getId()
-                  );
-              var searchFeature = olFeature.clone();
-              // copy the properties and id manually, not captured in a clone
-              searchFeature.setId('P_' + olFeature.getId());
-              searchFeature.properties = olFeature.properties;
-
-              searchResults.getSource().addFeature(searchFeature);
-            };
-
-            scope.unpinFeature = function() {
-              var searchResults;
-              mapService.map.getLayers().forEach(function(layer) {
-                if (layer.get('metadata').searchResults) {
-                  searchResults = layer;
-                }
-              });
-              // sanity check
-              if (!goog.isDefAndNotNull(searchResults)) {
-                return;
-              }
-              // remove the selected feature to the pinned search result
-              var olFeature =
-                  featureManagerService.getSelectedLayer().getSource().getFeatureById(
-                      featureManagerService.getSelectedItem().getId()
-                  );
-              searchResults.getSource().removeFeature(olFeature);
             };
           }
         };

--- a/src/common/featuremanager/partial/attributeedit.tpl.html
+++ b/src/common/featuremanager/partial/attributeedit.tpl.html
@@ -33,21 +33,10 @@
           <datetimepicker ng-switch-when="xsd:dateTime" date-object="prop[1]" default-date="inserting"></datetimepicker>
           <datetimepicker ng-switch-when="xsd:date" date-object="prop[1]" default-date="inserting" time="false"></datetimepicker>
           <datetimepicker ng-switch-when="xsd:time" date-object="prop[1]" default-date="inserting" date="false"></datetimepicker>
-          <div ng-switch-when="simpleType" class="input-group"  ng-class="{'has-error': !prop.valid}">
-            <div class="input-group-btn" ng-class="{'dropup': $last}">
-              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu">
-                <li>
-                  <a ng-click="selectValue(prop, null)">&nbsp;</a>
-                </li>
-                <li ng-repeat="enum in prop.enum">
-                  <a ng-click="selectValue(prop, $index)">{{enum._value}}</a>
-                </li>
-              </ul>
-          </div>
-            <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)" disabled/>
+          <div ng-switch-when="simpleType" ng-class="{'has-error': !prop.valid}">
+            <select ng-model="prop[1]" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in prop.enum" ng-change="validateField(prop, 1)" class="form-control">
+              <option></option>
+            </select>
           </div>
           <div ng-switch-when="xsd:int" ng-class="{'has-error': !prop.valid}">
             <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)"/>

--- a/src/common/featuremanager/partial/featureinfobox.tpl.html
+++ b/src/common/featuremanager/partial/featureinfobox.tpl.html
@@ -41,10 +41,10 @@
       <span class="info-box-attribute" ng-show="!isShowingAttributes()" translate="no_attributes"></span>
       <span ng-repeat="prop in featureManagerService.getSelectedItemProperties()">
         <div ng-if="!featureManagerService.isMediaPropertyName(prop[0])" ng-show="isAttributeVisible(prop[0])">
-          <span class="info-box-attribute">{{prop[0]}}</span>
+          <span class="info-box-attribute">{{getAttributeLabel(prop[0])}}</span>
             <span ng-switch on="isUrl(prop[1])">
               <a ng-switch-when="true" class="info-box-attribute-value" target="_blank" href="{{prop[1]}}">{{prop[1]}}</a>
-              <span ng-switch-default class="info-box-attribute-value">{{prop[1]}}</span>
+              <span ng-switch-default class="info-box-attribute-value">{{getAttributeValue(prop[0], prop[1])}}</span>
             </span>
         </div>
       </span>

--- a/src/common/geogig/GeoGigService.js
+++ b/src/common/geogig/GeoGigService.js
@@ -300,7 +300,7 @@
         // TODO: Use the OpenLayers parser once it is done
         var x2js = new X2JS();
         var json = x2js.xml_str2json(response.data);
-        var schema = [];
+        var schema = {};
         if (goog.isDefAndNotNull(json.schema)) {
           var savedSchema = layer.get('metadata').savedSchema;
           forEachArrayish(json.schema.complexType.complexContent.extension.sequence.element, function(obj) {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -910,15 +910,36 @@
               };
               wfsReqConfig.headers = serverService_.getWfsRequestHeaders(server);
 
-              httpService_.post(wfsurl, wfsRequestData, wfsReqConfig)
+              return httpService_.post(wfsurl, wfsRequestData, wfsReqConfig)
               .success(_handlePostResponse);
 
             };
-            geogigService_.isGeoGig(layer, server, fullConfig).then(function() {
-              testReadOnly();
+            var geogigPromise = geogigService_.isGeoGig(layer, server, fullConfig).then(function() {
+              return testReadOnly();
             }, function() {
-              testReadOnly();
+              return testReadOnly();
             });
+
+            var layerName = layer.getSource().getParams()['LAYERS'] || layer.getSource().getParams()['layers'];
+
+            // Fetch the Exchange layer metadata
+            var exchangePromise = httpService_.get('/layers/' + layerName + '/get').success(function(response) {
+              response.attributes = _.sortBy(response.attributes, 'display_order');
+              layer.set('exchangeMetadata', response);
+            });
+
+            q_.all([geogigPromise, exchangePromise]).then(function(data) {
+              _.each(layer.get('metadata').schema, function(schemaAttribute) {
+                var exchangeMetadata = layer.get('exchangeMetadata');
+                if (goog.isDefAndNotNull(exchangeMetadata) && goog.isDefAndNotNull(exchangeMetadata.attributes)) {
+                  var exchangeAttribute = _.find(exchangeMetadata.attributes, { attribute: schemaAttribute._name });
+                  if (goog.isDefAndNotNull(exchangeAttribute)) {
+                    schemaAttribute.visible = exchangeAttribute.visible;
+                  }
+                }
+              });
+            });
+
           }
         } else if (server.ptype === 'gxp_tmssource') {
           nameSplit = fullConfig.Name.split(':');

--- a/src/common/tableview/partial/tableview.tpl.html
+++ b/src/common/tableview/partial/tableview.tpl.html
@@ -41,13 +41,19 @@
           </tr>
           <tr>
             <th>{{'feature_id' | translate}}</th>
-            <th ng-repeat="attr in attributes" class="pointer" ng-click="selectAttribute(attr)" ng-class="{selectedAttribute: attr.selected}">{{attr.name}}</th>
+            <th ng-repeat="attr in attributes" class="pointer" ng-click="selectAttribute(attr)" ng-class="{selectedAttribute: attr.selected}">{{getAttributeLabel(attr.name)}}</th>
           </tr>
         </thead>
         <tr ng-repeat="row in rows" ng-class="{selectedRow: row.selected}" ng-click="selectFeature(row)">
           <td>{{row.feature.id}}</td>
-          <td ng-repeat="attr in attributes track by $index" ng-class="{'table-editing': tableviewform.$visible}">
-            <div ng-switch on="restrictions[attr.name].type" ng-class="{'wide-table-element': advFilters}">
+          <td ng-repeat="attr in attributes track by $index" ng-class="{'table-editing': tableviewform.$visible, 'has-error': attributeHasErrors(row, attr.name)}">
+            <div ng-switch on="restrictions[attr.name].type" ng-class="{'wide-table-element': advFilters}" ng-if="isAttributeReadonly(attr.name)">
+              <span ng-switch-when="datetime">{{row.feature.properties[attr.name] | date:"MM/dd/yyyy @ h:mm a"}}</span>
+              <span ng-switch-when="date">{{row.feature.properties[attr.name] | date:"MM/dd/yyyy"}}</span>
+              <span ng-switch-when="time">{{row.feature.properties[attr.name] | date:"h:mm a"}}</span>
+              <span ng-switch-default>{{getAttributeValue(attr.name, row.feature.properties[attr.name])}}</span>
+            </div>
+            <div ng-switch on="restrictions[attr.name].type" ng-class="{'wide-table-element': advFilters}" ng-if="!isAttributeReadonly(attr.name)">
               <span ng-switch-when="" editable-text="row.feature.properties[attr.name]" e-form="tableviewform"
                     e-style="width:160px">{{row.feature.properties[attr.name]}}</span>
               <span ng-switch-when="noEdit">{{row.feature.properties[attr.name]}}</span>
@@ -71,21 +77,10 @@
                                     default-date="false" seperate-time="false" date="false"></datetimepicker>
                 </div>
               <div ng-switch-default class="input-group">
-                <span ng-if="!tableviewform.$visible">{{row.feature.properties[attr.name]}}</span>
-                <div ng-if="tableviewform.$visible" class="input-group-btn" ng-class="{'dropup': $last}">
-                  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu">
-                    <li>
-                      <a ng-click="selectValue(row.feature.properties, attr.name, null)">&nbsp;</a>
-                    </li>
-                    <li ng-repeat="enum in restrictions[attr.name].type">
-                      <a ng-click="selectValue(row.feature.properties, attr.name, $index)">{{enum._value}}</a>
-                    </li>
-                  </ul>
-                </div>
-                <input ng-if="tableviewform.$visible" ng-model="row.feature.properties[attr.name]" type="text" class="table-dropdown form-control" disabled/>
+                <span ng-if="!tableviewform.$visible">{{getAttributeValue(attr.name, row.feature.properties[attr.name])}}</span>
+                <select ng-if="tableviewform.$visible" ng-model="row.feature.properties[attr.name]" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in restrictions[attr.name].type" class="form-control" style="width:160px">
+                  <option></option>
+                </select>
               </div>
             </div>
           </td>


### PR DESCRIPTION
## What does this PR do?

Allow the user to configure attribute visibility in Exchange for a given layer and have MapLoom honor it.

### Screenshot

<img width="1059" alt="screen shot 2017-09-28 at 10 58 15 pm" src="https://user-images.githubusercontent.com/947403/31000361-a4f1455a-a4a0-11e7-891a-f04f941ba9d2.png">
<img width="1168" alt="screen shot 2017-09-28 at 10 57 49 pm" src="https://user-images.githubusercontent.com/947403/31000360-a4efe016-a4a0-11e7-8fb2-f97cc7855b78.png">
<img width="557" alt="screen shot 2017-09-28 at 10 57 37 pm" src="https://user-images.githubusercontent.com/947403/31000362-a4f23384-a4a0-11e7-9a93-d8e1455fa47b.png">


### Related Issue
Cherry-picked from @boundlessgeo-yancy 's contribution to another branch, this completes the workflow such that the web mapping client and the mobile form for IOS and Andriod all display the same information for the layers attributes.