### PR TITLE
Restricting spatial filters to features with geometries

### DIFF
--- a/src/common/featuremanager/partial/featureinfobox.tpl.html
+++ b/src/common/featuremanager/partial/featureinfobox.tpl.html
@@ -52,7 +52,8 @@
 
     <div id="feature-info-box-bottom" ng-if="!featureManagerService.getSelectedLayer().get('metadata').searchLayer && !featureManagerService.getSelectedLayer().get('metadata').searchResults">
       <div id="feature-info-box-button-group" class="btn-group pull-right">
-        <button type="button" ng-if="!featureManagerService.getSelectedLayer().get('metadata').spatialFilterLayer" ng-click="setAsSpatialFilter()" tooltip-append-to-body="true" tooltip-placement="top"
+        <button type="button" ng-if="!featureManagerService.getSelectedLayer().get('metadata').spatialFilterLayer && featureManagerService.getSelectedItem().geometry"
+                ng-click="setAsSpatialFilter()" tooltip-append-to-body="true" tooltip-placement="top"
                 tooltip="{{'set_spatial_filter' | translate}}" class="btn btn-sm btn-default glyphicon glyphicon-filter">
         </button>
         <button type="button" ng-if="!featureManagerService.getSelectedLayer().get('metadata').spatialFilterLayer" ng-click="showTable(featureManagerService.getSelectedLayer())" tooltip-append-to-body="true" tooltip-placement="top"


### PR DESCRIPTION
## What does this PR do?
Now users can only create spatial filters using features with geometries, instead of allowing spatial filters to be created from any feature and then displaying an error.

### Screenshot
Resulting feature info popup:
<img width="258" alt="screen shot 2017-10-13 at 10 53 05 am" src="https://user-images.githubusercontent.com/4530776/31554942-cdd65496-b004-11e7-8e30-d9d7a02a1b03.png">

### Related Issue
[NODE-1177](https://issues.boundlessgeo.com:8443/browse/NODE-1177)

### Steps
1. Upload a GeoTIFF layer.
2. Publish the layer.
3. Create a map from the layer.
4. Click on a feature in the layer.
5. The "Use this feature in a spatial filter" will no longer be displayed in the feature info popup.