### PR TITLE
Changed pop-ups to show up under legend

### DIFF
--- a/src/common/featuremanager/style/featuremanager.less
+++ b/src/common/featuremanager/style/featuremanager.less
@@ -11,9 +11,7 @@
   white-space:nowrap;
   text-overflow: ellipsis;
   min-width: 250px;
-
-  /* ensure that the popup box comes on top of the legend */
-  z-index: 1000;
+  z-index: 250;
 
   &:after, &:before {
     top: 100%;

--- a/src/common/legend/style/legend.less
+++ b/src/common/legend/style/legend.less
@@ -3,7 +3,7 @@
   right: 50px;
   left: auto;
   top: 0;
-  .z-index(@mapLevel);
+  z-index: 500;
   background-color: @legendColor !important;
   color: @legendFontColor;
   width: auto;


### PR DESCRIPTION
Pop-ups to show up under legend and moved both down in z-index priority

<img width="652" alt="screenshot 2017-11-17 09 57 11" src="https://user-images.githubusercontent.com/3987/32956177-b523e30c-cb7d-11e7-82f6-775d1c307819.png">

### Related Issue
https://issues.boundlessgeo.com:8443/browse/BEX-383