### PR TITLE
Fix all the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+dist: trusty
+sudo: required
+
 language: node_js
+
 node_js:
-- '0.12'
-- '0.10'
+  - "8"
+
 before_script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -572,7 +572,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       for (var index = 0; index < layersConfig.length; index += 1) {
         var hasConfig = false;
         var lName = layersConfig[index].name || layersConfig[index].Name || '';
-        if (layersConfig[index].name === layerName || (lName.includes(layerName))) {
+        if (layersConfig[index].name === layerName || (lName.indexOf(layerName) >= 0)) {
           hasConfig = true;
         }
         if (goog.isDefAndNotNull(layersConfig[index].uuid) && layersConfig[index].uuid === layerId || !goog.isDefAndNotNull(layersConfig[index].uuid) && layersConfig[index].Name === layerName) {

--- a/src/common/featuremanager/FeatureInfoBoxDirective.js
+++ b/src/common/featuremanager/FeatureInfoBoxDirective.js
@@ -177,6 +177,73 @@
                 featureManagerService.hide();
               }
             };
+
+            scope.pinFeature = function() {
+              var searchResults;
+              mapService.map.getLayers().forEach(function(layer) {
+                if (layer.get('metadata').searchResults) {
+                  searchResults = layer;
+                }
+              });
+              // create pinned features layer if it does not exist yet
+              if (!goog.isDefAndNotNull(searchResults)) {
+                searchResults = new ol.layer.Vector({
+                  metadata: {
+                    title: $translate.instant('pinned_search'),
+                    internalLayer: true,
+                    searchResults: true
+                  },
+                  source: new ol.source.Vector({
+                    parser: null
+                  }),
+                  style: function(feature, resolution) {
+                    return [new ol.style.Style({
+                      image: new ol.style.Circle({
+                        radius: 8,
+                        fill: new ol.style.Fill({
+                          color: '#FF0000'
+                        }),
+                        stroke: new ol.style.Stroke({
+                          color: '#000000'
+                        })
+                      })
+                    })];
+                  }
+                });
+                // add the search results to the map
+                mapService.map.addLayer(searchResults);
+              }
+              // add a clone of the selected feature to the pinned search result
+              var olFeature =
+                  featureManagerService.getSelectedLayer().getSource().getFeatureById(
+                      featureManagerService.getSelectedItem().getId()
+                  );
+              var searchFeature = olFeature.clone();
+              // copy the properties and id manually, not captured in a clone
+              searchFeature.setId('P_' + olFeature.getId());
+              searchFeature.properties = olFeature.properties;
+
+              searchResults.getSource().addFeature(searchFeature);
+            };
+
+            scope.unpinFeature = function() {
+              var searchResults;
+              mapService.map.getLayers().forEach(function(layer) {
+                if (layer.get('metadata').searchResults) {
+                  searchResults = layer;
+                }
+              });
+              // sanity check
+              if (!goog.isDefAndNotNull(searchResults)) {
+                return;
+              }
+              // remove the selected feature to the pinned search result
+              var olFeature =
+                  featureManagerService.getSelectedLayer().getSource().getFeatureById(
+                      featureManagerService.getSelectedItem().getId()
+                  );
+              searchResults.getSource().removeFeature(olFeature);
+            };
           }
         };
       }


### PR DESCRIPTION
## What does this PR do?

1. Removes use of `String.include` as it was causing test failures.
   My suspcion is that this is due to an issue with the PhantomJS
   test runner not supporting this specific string function. It may have
   worked in browser but was failing in the testing environment.

2. Restores pin/unpin functions that were removed in a merge.
   As the tests for pinning features still existed, I assume the feature
   is still in the application. The functions are restored and the tests
   now pass.


### Screenshot

### Related Issue
