### PR TITLE
Fix for escapeXml with non-strings.

### DIFF
--- a/src/common/featuremanager/FeatureManagerService.spec.js
+++ b/src/common/featuremanager/FeatureManagerService.spec.js
@@ -270,6 +270,10 @@ describe('FeatureManagerService', function() {
           httpBackend.flush();
           httpBackend.expectPOST();
 
+          // test escapeXml under more situations.
+          expect(escapeXml(2)).toBe(2);
+          expect(escapeXml(undefined)).toBe(undefined);
+          expect(escapeXml(null)).toBe(null);
           expect(escapeXml('X&Y')).toBe('X&amp;Y');
 
           expect(wfsURL.indexOf('wfs')).not.toBe(-1);

--- a/src/common/utils/Globals.js
+++ b/src/common/utils/Globals.js
@@ -309,5 +309,9 @@ var mgrsToXYFormat = function(string) {
  * @return {string} A string which is "safe" for XML.
  */
 var escapeXml = function(str) {
-  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  // duck-types str as a string when the replace function is available.
+  if (str !== undefined && str !== null && typeof str.replace === 'function') {
+    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+  return str;
 };


### PR DESCRIPTION
## What does this PR do

Added additional checks and tests to ensure that the escapeXml
function handles malformed inputs. This will not properly return
strings, numbers, and non-objects such as null and undefined.


### Screenshot

### Related Issue

bex-462
