### PR TITLE
Specify WMS Version for GetCapabilities

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -541,7 +541,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       var namespace = layerName.split(':')[0];
       var name = layerName.split(':')[1];
       url = url.substring(0, url.lastIndexOf('/')) + '/' + namespace;
-      url += '/' + name + '/wms?request=GetCapabilities';
+      url += '/' + name + '/wms?request=GetCapabilities&version=1.1.1';
       server.populatingLayersConfig = true;
       var config = {};
       config.headers = {};
@@ -992,7 +992,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         }
 
         var iqm = url.indexOf('?');
-        var url_getcaps = url + (iqm >= 0 ? (iqm - 1 == url.length ? '' : '&') : '?') + 'SERVICE=WMS&REQUEST=GetCapabilities';
+        var url_getcaps = url + (iqm >= 0 ? (iqm - 1 == url.length ? '' : '&') : '?') + 'SERVICE=WMS&REQUEST=GetCapabilities&version=1.1.1';
 
         server.populatingLayersConfig = true;
         var config = {};

--- a/src/common/geogig/GeoGigService.js
+++ b/src/common/geogig/GeoGigService.js
@@ -420,7 +420,6 @@
       // This should always be the last thing that gets done.
       var getFeatureType = function() {
         service_.getFeatureType(layer).then(function() {
-          ol.proj.getTransform(metadata.projection, 'EPSG:4326');
           rootScope.$broadcast('featuretype-added', layer);
           deferredResponse.resolve();
         }, function(rejected) {


### PR DESCRIPTION
## What does this PR do?

The code for parsing bounding boxes is specific to WMS 1.1.X
GetCapbilities format. Newer version of GeoServer default to WMS 1.3.

This forces the GetCapabilities call to use 1.1.1 and removes a line
of dead projection parsing code which was causing an error when the
server is configured without GeoGig.


### Screenshot

### Related Issue

https://github.com/boundlessgeo/MapLoom/pull/112
BEX-418
