### PR TITLE
Legends now refresh when the styles change

### DIFF
--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -13,6 +13,7 @@
           link: function(scope, element) {
             scope.mapService = mapService;
             scope.serverService = serverService;
+            scope.legendTime = (new Date()).getTime();
 
             var openLegend = function() {
               angular.element('#legend-container')[0].style.visibility = 'visible';
@@ -121,6 +122,8 @@
                 layer: layer.get('metadata').name
               };
 
+              params['_dc'] = scope.legendTime;
+
               // parse the server url
               var uri = new goog.Uri(domain);
               // mix in the paramters
@@ -142,6 +145,11 @@
               if (legendOpen === true && angular.element('.legend-item').length == 1) {
                 closeLegend();
               }
+            });
+
+            scope.$on('layers-styled', function() {
+              // update the last-refresh legend time to freshen the legends
+              scope.legendTime = (new Date()).getTime();
             });
           }
         };

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -365,6 +365,8 @@
             if (goog.isDefAndNotNull(layerSource.updateParams)) {
               layerSource.updateParams({'_dc': new Date().getTime(), '_olSalt': Math.random()});
             }
+
+            rootScope_.$broadcast('layers-styled');
           });
         }
       }


### PR DESCRIPTION
## What does this PR do?

1. Created a new topic `layers-styled` that is broadcast
   whenever a layers style is updated.
2. Added a new `_dc` - "defeat cache" to the end of the
   legend request.
3. Whenever the `layers-styled` message is broadcast,
   the legend directive changes the `_dc` value for all legends
   causing them to refresh.

### Related Issue

BEX-413
