### PR TITLE
Fix for advanced filters

### DIFF
--- a/src/common/tableview/partial/filteroptions.tpl.html
+++ b/src/common/tableview/partial/filteroptions.tpl.html
@@ -7,8 +7,8 @@
                     ng-if="filterType === 'date'" default-date="false" time="false" seperate-time="false"></datetimepicker>
     <datetimepicker id="start-date" class="no-radius" style="padding-top: 15px" date-object="attribute.filter.text" ng-disabled="attribute.filter.searchType === 'numRange'"
                     ng-if="filterType === 'time'" default-date="false" date="false" seperate-time="false"></datetimepicker>
-    <div class="input-group-btn">
-        <button type="button" class="btn btn-default dropdown-toggle" ng-class="{'dirty-filter': dirty}">
+    <div class="input-group-btn dropdown">
+        <button type="button" class="btn btn-default dropdown-toggle" ng-class="{'dirty-filter': dirty}" data-toggle="toggle">
             <span class="caret"></span>
         </button>
         <ul class="dropdown-menu">


### PR DESCRIPTION
## What does this PR do?

Bootstrap was made angry and not picking up the drop-down controls.

Added additional 'hints' for Bootstrap to automatically work the
drop-down tools.

### Screenshot

### Related Issue

BEX-466
