### PR TITLE
Fix Attribute Editing

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -541,7 +541,7 @@ var SERVER_SERVICE_USE_PROXY = true;
       var namespace = layerName.split(':')[0];
       var name = layerName.split(':')[1];
       url = url.substring(0, url.lastIndexOf('/')) + '/' + namespace;
-      url += '/' + name + '/wms?request=GetCapabilities&version=1.1.1';
+      url += '/' + name + '/wms?request=GetCapabilities';
       server.populatingLayersConfig = true;
       var config = {};
       config.headers = {};
@@ -992,7 +992,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         }
 
         var iqm = url.indexOf('?');
-        var url_getcaps = url + (iqm >= 0 ? (iqm - 1 == url.length ? '' : '&') : '?') + 'SERVICE=WMS&REQUEST=GetCapabilities&version=1.1.1';
+        var url_getcaps = url + (iqm >= 0 ? (iqm - 1 == url.length ? '' : '&') : '?') + 'SERVICE=WMS&REQUEST=GetCapabilities';
 
         server.populatingLayersConfig = true;
         var config = {};

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -452,12 +452,16 @@
 
     this.zoomToLayerExtent = function(layer) {
       var metadata = layer.get('metadata');
+      // determine the CRS based on the metadata available.
+      var layer_crs = metadata.bbox.crs ? metadata.bbox.crs : metadata.bbox.extent.crs;
+
       var shrinkExtent = function(extent, shrink) {
-        var newExtent = extent;
+        // differences between GeoServer 2.11 / 2.12
+        var newExtent = Array.isArray(extent) ? extent : extent.extent;
 
         // If the extent is null, make a new one while shrinking based on factor
         if (!goog.isDefAndNotNull(extent) && goog.isDefAndNotNull(metadata) &&
-            goog.isDefAndNotNull(metadata.bbox.crs)) {
+            goog.isDefAndNotNull(layer_crs)) {
           newExtent = goog.array.clone(metadata.bbox.extent);
           var yDelta = (newExtent[3] - newExtent[1]) * shrink;
           var xDelta = (newExtent[2] - newExtent[0]) * shrink;
@@ -468,8 +472,9 @@
         }
 
         // Create transform and project to current map
-        var transform = ol.proj.getTransformFromProjections(ol.proj.get(metadata.bbox.crs),
+        var transform = ol.proj.getTransformFromProjections(ol.proj.get(layer_crs),
             service_.map.getView().getProjection());
+
         newExtent = ol.extent.applyTransform(newExtent, transform);
 
         return newExtent;
@@ -873,7 +878,6 @@
               crs: fullConfig.CRS[0]
             };
           }
-
           layer = new ol.layer.Tile({
             metadata: {
               serverId: server.id,


### PR DESCRIPTION
## What does this PR do?
This error is related to using GetCaps 1.1.1. The projection
was not parsed correctly as the Openlayers GetCaps parser assumes
the 1.3.0 nomenclature.  Therefore, the layer's SRS was not transformed
or interpreted as expected (that is as the CRS as the 1.3.0 spec calls for).

This fix reverts the change to the 1.1.1 version of GetCaps but ultimately
still fixes the zoom-to errors that were happening before.

## Related Issues
BEX-469, BEX-418, PR #114
