### PR TITLE
Only lazy load if sending the layer query string param.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -350,6 +350,10 @@ var SERVER_SERVICE_USE_PROXY = true;
         lazy: false
       };
 
+      if (!window.location.search.includes('layer=')) {
+        server.lazy = true;
+      }
+
       goog.object.extend(server, serverInfo, {});
 
       if (goog.isDefAndNotNull(loaded)) {


### PR DESCRIPTION
This PR addresses the issue where getCapabilities requests are made when opening a new map without any layers thus causing a delay in loading the layers panel. With this fix, the getCapabilities request will only be executed if the url query param layer=<my_layer_name> is provided. 

Note: There is a follow on fix that will change the layer pre-fetch behavior. Basically query elastic rather than doing a getCapabilities look up when the layer=<my_layer_name> query param is provided