### PR TITLE
Prepend workspace name to typename in tableview

### DIFF
--- a/src/common/tableview/TableViewDirective.js
+++ b/src/common/tableview/TableViewDirective.js
@@ -402,10 +402,17 @@
                   continue;
                 }
                 var feature = scope.rows[index].feature;
+                var metadata = tableViewService.selectedLayer.get('metadata');
+                var typeName = metadata.name;
+
+                if (!typeName.startsWith(metadata.workspace + ':')) {
+                  typeName = metadata.workspace + ':' + metadata.name;
+                }
+
                 xml += '' +
                     '<wfs:Update' +
-                    ' xmlns:feature="' + tableViewService.selectedLayer.get('metadata').workspaceURL + '" ' +
-                    'typeName="' + tableViewService.selectedLayer.get('metadata').name + '">';
+                    ' xmlns:feature="' + metadata.workspaceURL + '" ' +
+                    'typeName="' + typeName + '">';
                 for (var property in feature.properties) {
                   var value = feature.properties[property];
                   xml += '<wfs:Property>' +

--- a/src/common/tableview/TableViewService.js
+++ b/src/common/tableview/TableViewService.js
@@ -273,6 +273,11 @@
         }
       }
 
+      var typeName = metadata.name;
+      if (!typeName.startsWith(metadata.workspace + ':')) {
+        typeName = metadata.workspace + ':' + metadata.name;
+      }
+
       var xml = '';
       if (!goog.isDefAndNotNull(exclude_header) || exclude_header === false) {
         xml += '<?xml version="1.0" encoding="UTF-8"?>';
@@ -286,7 +291,7 @@
           ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
           ' xsi:schemaLocation="http://www.opengis.net/wfs' +
           ' http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">' +
-          '<wfs:Query typeName="' + metadata.name + '"' +
+          '<wfs:Query typeName="' + typeName + '"' +
           ' srsName="' + 'EPSG:3857' + '"' +
           //' srsName="' + metadata.projection + '"' +
           '>';


### PR DESCRIPTION
Fixes an issue where WPS calls are failing because of a missing workspace in tableview