### PR TITLE
Do not lazy load if viewing a saved map

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -350,7 +350,7 @@ var SERVER_SERVICE_USE_PROXY = true;
         lazy: true
       };
 
-      if (window.location.search.indexOf('layer=') >= 0) {
+      if (window.location.search.indexOf('layer=') >= 0 || window.location.pathname.indexOf('/view') >= 0) {
         server.lazy = false;
       }
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where loading a saved map attempts to lazy load the layer which results in the layer being disabled.
