### PR TITLE
Layers of type mapproxy-tms always visible

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -803,7 +803,7 @@
                 crs: service_.getCRSCode(fullConfig.CRS)
               }
             },
-            visible: true,
+            visible: (minimalConfig.visibility !== false),
             source: src
           });
         } else if (server.ptype === 'gxp_osmsource') {


### PR DESCRIPTION
## What does this PR do?

The minimal config was not being honour for layers of type
mapproxy_tms. The settings is now properly parsed.


### Screenshot

### Related Issue
