### PR TITLE
Allow SurfacePropertyType and MultiSurfacePropertyType

### DIFF
--- a/src/common/geogig/GeoGigService.js
+++ b/src/common/geogig/GeoGigService.js
@@ -316,7 +316,7 @@
             schema[obj._name].visible = true;
             if (obj._type.indexOf('gml:') != -1) {
               var lp = obj._type.substring(4);
-              if (lp.indexOf('Polygon') !== -1 || lp.indexOf('MultiSurfacePropertyType') !== -1) {
+              if (lp.indexOf('Polygon') !== -1 || lp.indexOf('SurfacePropertyType') !== -1) {
                 geometryType = 'polygon';
               } else if (lp.indexOf('LineString') !== -1) {
                 geometryType = 'line';


### PR DESCRIPTION
## What does this PR do?

Allows Maploom to set the geomType when `gml:SurfacePropertyType` or `gml:MultiSurfacePropertyType` is returned from the WFS DescribeFeature request.

The snippet below is an example response that raised the issue.

```
<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:geonode="http://geonode" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" targetNamespace="http://geonode">
  <xsd:import namespace="http://www.opengis.net/gml" schemaLocation="https://exchange.boundlessgeo.io/geoserver/schemas/gml/3.1.1/base/gml.xsd?access_token=d0x1l720SkSKj63EwOgVg5LhO7rQjM"/>
  <xsd:complexType name="policedistrict_c9f6e591Type">
    <xsd:complexContent>
      <xsd:extension base="gml:AbstractFeatureType">
        <xsd:sequence>
          <xsd:element maxOccurs="1" minOccurs="0" name="dist_label" nillable="true" type="xsd:string"/>
          <xsd:element maxOccurs="1" minOccurs="0" name="dist_num" nillable="true" type="xsd:string"/>
          <xsd:element maxOccurs="1" minOccurs="0" name="wkb_geometry" nillable="true" type="gml:SurfacePropertyType"/>
        </xsd:sequence>
      </xsd:extension>
    </xsd:complexContent>
  </xsd:complexType>
  <xsd:element name="policedistrict_c9f6e591" substitutionGroup="gml:_Feature" type="geonode:policedistrict_c9f6e591Type"/>
</xsd:schema>
```

### Screenshot

<img width="254" alt="screen shot 2018-01-05 at 6 34 22 am" src="https://user-images.githubusercontent.com/947403/34609563-eb4d12c4-f1e2-11e7-91d1-93afd6b0dfce.png">
<img width="278" alt="screen shot 2018-01-05 at 6 36 49 am" src="https://user-images.githubusercontent.com/947403/34609564-eb5c44b0-f1e2-11e7-8d1a-a551aa972878.png">


### Related Issue
