### PR TITLE
CSS change to make "pop UP" menus.

### DIFF
--- a/src/common/layers/style/layers.less
+++ b/src/common/layers/style/layers.less
@@ -144,3 +144,8 @@ div.carousel-inner>.item>.item {
   background-color: #285172;
   background-image: none;
 }
+
+style-editor .dropdown-menu {
+	bottom: 0;
+	top: unset;
+}


### PR DESCRIPTION
## What does this PR do?
This will have the popup menus inside of the style
editor pop "up" instead of down. This works better
in most cases for spacing.

### Screenshot

![image](https://user-images.githubusercontent.com/1282291/34690289-26f435ee-f47e-11e7-9dd4-b2ccc188f736.png)

### Related Issue

refs: BEX-570
