### PR TITLE
Limit the avilable font types

### DIFF
--- a/src/common/layers/LayersDirective.js
+++ b/src/common/layers/LayersDirective.js
@@ -168,6 +168,14 @@
             scope.getLayerAttributeVisibility = function(layer) {
               $rootScope.$broadcast('getLayerAttributeVisibility', layer);
             };
+
+            scope.updateStyleChoices = function(styleChoices) {
+              var overrides = {
+                fontFamily: ['serif', 'sans-serif']
+              };
+
+              return Object.assign({}, styleChoices, overrides);
+            };
           }
         };
       }

--- a/src/common/layers/partials/layers.tpl.html
+++ b/src/common/layers/partials/layers.tpl.html
@@ -92,7 +92,13 @@
           </a>
           </div>
           <div id="styleRow" class="container" ng-show="stylingEnabled && layer.get('metadata').editable && layer.get('metadata').showStylePanel">
-              <style-editor class="minheight" control="{carousel:true, default:false}" layer="layer" ng-show="layer.get('metadata').editable"></style-editor>
+              <style-editor
+                class="minheight"
+                control="{carousel:true, default:false}"
+                layer="layer"
+                update-style-choices="updateStyleChoices"
+                ng-show="layer.get('metadata').editable">
+            </style-editor>
           </div>
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?
Limits font families to serif and sans-serif.

### Screenshot

### Related Issue
refs: BEX-568

Depends on: https://github.com/boundlessgeo/story-tools/pull/1
