### PR TITLE
Working remote services

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -127,7 +127,9 @@
     for (var src_key in config.sources) {
         if (goog.isDefAndNotNull(config.sources[src_key].url)) {
             if (config.sources[src_key].ptype != 'gxp_arcrestsource') {
-                config.sources[src_key].url = trimUrl(config.sources[src_key].url);
+                if (config.sources[src_key].remote !== true) {
+                    config.sources[src_key].url = trimUrl(config.sources[src_key].url);
+                }
             }
         }
     }


### PR DESCRIPTION

## What does this PR do?

1. Proxy WMS requests through the GeoNode proxy.
2. Handle the case where the source WMS does not support 900913 projections.
3. Prevent remote services from having their URL 'trimmed.'

### Screenshot

### Related Issue

BEX-556, BEX-557