### PR TITLE
Fix for over grown attribute popups.

### DIFF
--- a/src/common/layers/style/layers.less
+++ b/src/common/layers/style/layers.less
@@ -146,6 +146,7 @@ div.carousel-inner>.item>.item {
 }
 
 style-editor .dropdown-menu {
-	bottom: 0;
-	top: unset;
+    bottom: 0;
+    top: unset;
+    max-height: 80px;
 }


### PR DESCRIPTION
## What does this PR do?

The popups have DOM scoping issues that cause
them to occasionally be buried under other elements,
this limits the height minimizing the effect.


### Screenshot

### Related Issue

refs: BEX-570