### PR TITLE
 Fix for Arc-rest services without a trailing "/"

### DIFF
--- a/src/common/diff/FeatureDiffDirective.js
+++ b/src/common/diff/FeatureDiffDirective.js
@@ -13,7 +13,6 @@
               scope.authorsLoaded = false;
               scope.authorsShown = false;
               scope.isLoading = false;
-              scope.undoEnabled = true;
               scope.featureDiffService = featureDiffService;
               scope.editable = false;
               scope.readOnly = false;
@@ -23,6 +22,19 @@
                    !featureDiffService.layer.get('metadata').editable)) {
                 scope.readOnly = true;
               }
+
+              var old_commit;
+              var new_commit;
+              if (featureDiffService.change === 'MERGED') {
+                old_commit = featureDiffService.getOursId();
+                new_commit = featureDiffService.getMergedId();
+              } else {
+                old_commit = featureDiffService.getAncestorId();
+                new_commit = featureDiffService.getTheirsId();
+              }
+
+              scope.undoEnabled = (old_commit !== undefined && old_commit !== null && new_commit !== undefined && old_commit !== null && new_commit !== old_commit);
+
               switch (featureDiffService.change) {
                 case 'ADDED':
                   scope.rightTitle = $translate.instant('new_feature');

--- a/src/index.html
+++ b/src/index.html
@@ -130,6 +130,12 @@
                 if (config.sources[src_key].remote !== true) {
                     config.sources[src_key].url = trimUrl(config.sources[src_key].url);
                 }
+            } else {
+                // this is an arcgis rest source...
+                var url = config.sources[src_key].url;
+                if (url.substring(url.length - 1) !== '/') {
+                    config.sources[src_key].url = url + '/';
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?
When ArcGIS REST services are found in the configuration,
they now check that the trailing "/" exist

### Screenshot

### Related Issue

BEX-639