### PR TITLE
Various small fixes for loading remote services.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -368,33 +368,14 @@ var SERVER_SERVICE_USE_PROXY = true;
       var doWork = function() {
         service_.populateLayersConfig(server)
             .then(function(response) {
-              // set the id. it should always resolve to the length
-              if (goog.isDefAndNotNull(server.layersConfig) && server.layersConfig.length === 0 && !loaded &&
-                  server.lazy !== true) {
-                dialogService_.warn(translate_.instant('add_server'), translate_.instant('server_connect_failed'),
-                    [translate_.instant('yes_btn'), translate_.instant('no_btn')], false).then(function(button) {
-                  switch (button) {
-                    case 0:
-                      server.id = serverCount++;
-                      servers.push(server);
-                      rootScope_.$broadcast('server-added', server.id);
-                      deferredResponse.resolve(server);
-                      break;
-                    case 1:
-                      deferredResponse.reject(server);
-                      break;
-                  }
-                });
-              } else {
-                // If there are no layers on the server, layersConfig will be undefined.
-                if (!goog.isDefAndNotNull(server.layersConfig)) {
-                  server.layersConfig = [];
-                }
-                server.id = serverCount++;
-                servers.push(server);
-                rootScope_.$broadcast('server-added', server.id);
-                deferredResponse.resolve(server);
+              // add the server when the config is loaded.
+              if (!goog.isDefAndNotNull(server.layersConfig)) {
+                server.layersConfig = [];
               }
+              server.id = serverCount++;
+              servers.push(server);
+              rootScope_.$broadcast('server-added', server.id);
+              deferredResponse.resolve(server);
             }, function(reject) {
               deferredResponse.reject(reject);
             });

--- a/src/common/legend/partial/legend.tpl.html
+++ b/src/common/legend/partial/legend.tpl.html
@@ -16,7 +16,7 @@
                     data-target="{{'#' + layer.get('metadata').uniqueID + 'legend'}}">{{layer.get('metadata').title}}
                 </div>
                 <div class="panel-collapse legend-item in legend-panel-body" id="{{layer.get('metadata').uniqueID + 'legend'}}">
-                    <img ng-src="{{getLegendUrl(layer)}}">
+                    <img onError="this.style.display = 'none';" ng-src="{{getLegendUrl(layer)}}">
                 </div>
             </div>
         </div>

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1088,11 +1088,18 @@
               .success(_handlePostResponse);
 
             };
-            var geogigPromise = geogigService_.isGeoGig(layer, server, fullConfig).then(function() {
-              return testReadOnly();
-            }, function() {
-              return testReadOnly();
-            });
+            var geogigPromise;
+            // Skip the WFS feature check for remote services.
+            if (server.remote === true) {
+              geogigPromise = q_.defer();
+              geogigPromise.resolve(true);
+            } else {
+              geogigPromise = geogigService_.isGeoGig(layer, server, fullConfig).then(function() {
+                return testReadOnly();
+              }, function() {
+                return testReadOnly();
+              });
+            }
 
             var layerName = layer.getSource().getParams()['LAYERS'] || layer.getSource().getParams()['layers'];
 


### PR DESCRIPTION

## What does this PR do?

1. Removes the layers-count check for loaded WMS server configurations.
   There are some situations in the new setup that can have WMS GetCaps
   return zero layers. This removes that check and treats the server
   as valid so long as the response is valid (200 and parseable).
2. Added an onError check to legend <img>s
   Hide images which return an XML error, not all services support
   a GetLegendGraphic Request, the image will now be hidden in that
   case.
3. Remove the broken WFS request for remote services.
   There's no WFS proxying for remote layers.  This makes any
   remote service return as read-only.

### Screenshot

### Related Issue

BEX-646