### PR TITLE
Delay the time between intervals

### DIFF
--- a/src/common/timeline/TimelineService.js
+++ b/src/common/timeline/TimelineService.js
@@ -123,7 +123,7 @@
           interval_.cancel(intervalPromise_);
           intervalPromise_ = null;
         }
-      }, 1000);
+      }, 5000);
     };
 
     this.stop = function() {


### PR DESCRIPTION
## What does this PR do?

Moved the time delay from 1000ms to 5000ms, with only a 1000ms
delay, the layer was invalidating before it had the chance to load
the next set of tiles.

### Related Issue

BEX-676
