### PR TITLE
Disable animation by default for zoomto

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -309,7 +309,7 @@
 
     this.zoomToExtent = function(extent, animate, map, scale) {
       if (!goog.isDefAndNotNull(animate)) {
-        animate = true;
+        animate = false;
       }
       if (!goog.isDefAndNotNull(map)) {
         map = this.map;


### PR DESCRIPTION

## What does this PR do?
Animation was causing the zoom-to action to fail
to re-render the map.


### Screenshot

### Related Issue

BEX-696
