### PR TITLE
account for copy= so that layers load correctly for copied maps.

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -350,7 +350,9 @@ var SERVER_SERVICE_USE_PROXY = true;
         lazy: true
       };
 
-      if (window.location.search.indexOf('layer=') >= 0 || window.location.pathname.indexOf('/view') >= 0) {
+      if (window.location.search.indexOf('layer=') >= 0 ||
+          window.location.search.indexOf('copy=') >= 0 ||
+          window.location.pathname.indexOf('/view') >= 0) {
         server.lazy = false;
       }
 


### PR DESCRIPTION
## What does this PR do?
With out this fix, when a user attempts to create a map from a copied map, the layers are disabled. This change sets server.lazy to false when copy= is in the url params so the config can be hydrated.

### Screenshot

### Related Issue
