### PR TITLE
Fix addRemoteLayer function to allow adding a new layer when the serv…

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -704,15 +704,15 @@
               return $http.get(layer.detail_url + '/get').then(function(response) {
                 var layer_def = response.data;
                 var servers = serverService.getServers();
+                var server_to_use = null;
 
-                var server_exists = false;
                 for (var i = 0, ii = servers.length; i < ii; i++) {
                   if (servers[i].url === layer_def.url) {
-                    server_exists = true;
+                    server_to_use = servers[i];
                   }
                 }
 
-                if (!server_exists) {
+                if (server_to_use === null) {
                   // this may not be the most stable method for getting
                   //  the server name.
                   var server_name = layer.detail_url.split('/layers/')[1].split(':')[0];
@@ -728,6 +728,10 @@
                     layer.name = layer.typename;
                     LayersService.addLayer(layer, server.id, server);
                   });
+                } else {
+                  layer.add = true;
+                  layer.name = layer.typename;
+                  LayersService.addLayer(layer, server_to_use.id, server_to_use);
                 }
               });
             };


### PR DESCRIPTION
…er already exists

## What does this PR do?
Fixes a bug where you were unable to add more than one layer from a remote service via the add layers button in MapLoom

### Screenshot
N/A

### Related Issue
N/A
