### PR TITLE
Better typename resolution for remote layers.

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -725,7 +725,13 @@
                     name: server_name
                   }).then(function(server) {
                     layer.add = true;
-                    layer.name = layer.typename;
+                    // pick the "best of", different version of the code will
+                    //  or will not prefix the data source in the typename vs in the name.
+                    if (layer_def.name.split(':').length < layer_def.typename.split(':').length) {
+                      layer.name = layer_def.name;
+                    } else {
+                      layer.name = layer_def.typename;
+                    }
                     LayersService.addLayer(layer, server.id, server);
                   });
                 }

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1005,7 +1005,7 @@
           }
 
         } else if (server.ptype === 'gxp_wmscsource') {
-          nameSplit = fullConfig.Name.split(':');
+          nameSplit = (fullConfig.Name || fullConfig.name).split(':');
 
           // favor virtual service url when available
           var mostSpecificUrl = server.url;
@@ -1037,7 +1037,7 @@
           }
 
           var source_params = {
-            'LAYERS': minimalConfig.name,
+            'LAYERS': fullConfig.typeName || minimalConfig.name,
             'tiled': 'true'
           };
 


### PR DESCRIPTION
## What does this PR do?
Remote layer's typenames were getting all three colons (source:workspace:layer),
this attempts to detect the best option (name vs typename) and uses it
to create better reliability for rendering the layer.

### Screenshot

### Related Issue
