### PR TITLE
Fix for ArcGIS layer titles

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -579,6 +579,7 @@ var SERVER_SERVICE_USE_PROXY = true;
             var name = layer_conf.name.replace(/\./g, '').replace(/ /g, '-');
             layers_config.push(Object.assign(xhr.data.layers[i], {
               name: server.name + '_' + name.toLowerCase() + ':' + layer_conf.id,
+              Title: layer_conf.name,
               srs: sr_to_crs(xhr.data.spatialReference),
               extent: {
                 crs: sr_to_crs(extent.spatialReference),


### PR DESCRIPTION

## Issue Number
BEX-901

## What does this PR do?
The 'Title:' attribute was not being properly set from the server's
name for the layer.  This is now fixed.
