### PR TITLE
Hide Zoom Button when Unavailable

### DIFF
--- a/src/common/layers/LayersDirective.js
+++ b/src/common/layers/LayersDirective.js
@@ -178,6 +178,16 @@
               $rootScope.$broadcast('getLayerAttributeVisibility', layer);
             };
 
+            scope.canZoom = function(layer) {
+              // ensure the projection is "zoomable".
+              var metadata = layer.get('metadata');
+              if (metadata.bbox) {
+                var layer_crs = metadata.bbox.crs ? metadata.bbox.crs : metadata.bbox.extent.crs;
+                return (ol.proj.get(layer_crs) !== undefined);
+              }
+              return false;
+            };
+
             scope.updateStyleChoices = function(styleChoices) {
               var overrides = {
                 fontFamily: ['serif', 'sans-serif']

--- a/src/common/layers/partials/layers.tpl.html
+++ b/src/common/layers/partials/layers.tpl.html
@@ -31,7 +31,7 @@
       <div class="panel-body layer-inner-panel">
         <div class="btn-group-wrap">
           <div class="btn-group">
-            <a type="button" ng-show="!layer.get('metadata').placeholder" ng-click="zoomToData(layer)" tooltip-append-to-body="true"
+            <a type="button" ng-show="!layer.get('metadata').placeholder && canZoom(layer)" ng-click="zoomToData(layer)" tooltip-append-to-body="true"
                tooltip-placement="top" tooltip="{{'zoom_to_data' | translate}}"
                class="btn btn-sm btn-default">
               <div class="loom-loading" spinner-radius="16" spinner-hidden="!zooming"></div>


### PR DESCRIPTION


## Issue Number
BEX-905

## What does this PR do?
Some remote layers will not have a usable projection
for the zoom-to button.  This will detect when a valid projection
is present and show the button.  Otherwise, the button will be hidden.

