### PR TITLE
Hide Style Control for Raster Layers

### DIFF
--- a/src/common/layers/LayersDirective.js
+++ b/src/common/layers/LayersDirective.js
@@ -77,6 +77,15 @@
               var exchangeMetadata = layer.get('exchangeMetadata');
               var has_perms = false;
               if (goog.isDefAndNotNull(exchangeMetadata) && goog.isDefAndNotNull(exchangeMetadata.permissions)) {
+                // check for any raster attributes.
+                var attrs = exchangeMetadata.attributes;
+                for (var i = 0, ii = attrs.length; i < ii; i++) {
+                  // exit early if a raster attribute is found.
+                  if (attrs[i].attribute_type === 'raster') {
+                    return false;
+                  }
+                }
+
                 var permissions = exchangeMetadata.permissions;
                 if (goog.isDefAndNotNull(permissions)) {
                   has_perms = permissions.edit_style;


### PR DESCRIPTION

## Issue Number
BEX-902

## What does this PR do?

When a raster attribute is detected, hide the style
control.
