### PR TITLE
Remove "length" check from legend.

### DIFF
--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -32,9 +32,7 @@
 
             scope.toggleLegend = function() {
               if (legendOpen === false) {
-                if (angular.element('.legend-item').length > 0) {
-                  openLegend();
-                }
+                openLegend();
               } else {
                 closeLegend();
               }


### PR DESCRIPTION

## Issue Number
BEX-934

## What does this PR do?
As it is possible to get an "empty" legend panel with a set
of remote services, this will allow the panel to show/hide.  It looks
less broken but doesn't display any data.
