### PR TITLE
Grab correct ArcREST layer for tile services

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -978,7 +978,10 @@
           // This arc service does not support tiled maps, so this will
           // use the arc image service instead...
           serviceSource = new ol.source.TileArcGISRest({
-            url: rest_url
+            url: rest_url,
+            params: {
+              'LAYERS': 'show:' + fullConfig.id
+            }
           });
 
           // patch the web mercator projection.


### PR DESCRIPTION
## Issue Number
PSBEX-169

## What does this PR do?
Specifies a layer from the ArcREST service to be displayed in the map (previously, it always showed the default)

### Screenshot

### Related Issue
