### PR TITLE
Grab correct ArcREST layer for tile servcies

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -881,7 +881,10 @@
           // This arc service does not support tiled maps, so this will
           // use the arc image service instead...
           serviceSource = new ol.source.TileArcGISRest({
-            url: rest_url
+            url: rest_url,
+            params: {
+              'LAYERS': 'show:' + fullConfig.id
+            }
           });
 
           // patch the web mercator projection.


### PR DESCRIPTION
## Issue Number
BEX-951

## What does this PR do?
Specifies a layer from the ArcREST service to be displayed in the map (previously, it always showed the default)

### Screenshot

### Related Issue
