### PR TITLE
Fix hash for esprima

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,7 +3189,7 @@
       "dependencies": {
         "esprima": {
           "version": "https://github.com/ariya/esprima/tarball/master",
-          "integrity": "sha512-c+UYwIaDwhngPdQyvrdPT/IeIs3RkKsZFI8q5mcADMGBId801LfHRl/YeOmBqshyLiHcvu0uqJ7+k0Gy8NMfsw==",
+          "integrity": "sha512-W5+ntA5gmzYpBFDpLLw7yAJPohkq5yKF8JnP9UOaXSfnKcibZQcIM9anoxztmB2NwRWLLidEseBbuCdwgQsnig==",
           "dev": true
         },
         "underscore": {


### PR DESCRIPTION
## Issue Number

## What does this PR do?
Fixes checksum build error: https://travis-ci.org/boundlessgeo/MapLoom/builds/380696450
Possibly jshint is pulling a newer version of esprima, causing the hash not to match. Updating to the expected hash in package-lock.json allows it to build.

### Screenshot

### Related Issue
