### PR TITLE
Manually update esprima hash to fix CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,7 +3064,7 @@
             "esprima": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-              "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+              "integrity": "sha512-W5+ntA5gmzYpBFDpLLw7yAJPohkq5yKF8JnP9UOaXSfnKcibZQcIM9anoxztmB2NwRWLLidEseBbuCdwgQsnig==",
               "dev": true
             }
           }


### PR DESCRIPTION
## Issue Number
N/A

## What does this PR do?
Fixes a weird error with the CI due to an incorrect commit hash for the `esprima` package. The problem seems to be that `jshint` is pulling `esprima` from master instead of a specific release. This is a hotfix for the problem, but it's unclear to me why `jshint` is pulling the wrong version of `esprima` here.

CI build with the error: https://travis-ci.org/boundlessgeo/MapLoom/builds/389042796?utm_source=github_status&utm_medium=notification

### Screenshot
N/A

### Related Issue
Same thing as was done for ps/pki branch here: https://github.com/boundlessgeo/MapLoom/pull/181