### PR TITLE
patch esprima sha hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,7 +3189,7 @@
       "dependencies": {
         "esprima": {
           "version": "https://github.com/ariya/esprima/tarball/master",
-          "integrity": "sha512-W5+ntA5gmzYpBFDpLLw7yAJPohkq5yKF8JnP9UOaXSfnKcibZQcIM9anoxztmB2NwRWLLidEseBbuCdwgQsnig==",
+          "integrity": "sha512-Azo3aYdi0o01MuIigQd87VFiDCyRW5Z30rhwFCwdaGlvsPJu9R8CzZDCxffFEnjiqXZXzXjlZz30M3lczZugoA==",
           "dev": true
         },
         "underscore": {


### PR DESCRIPTION
## What does this PR do?
Because we are using an older version of jshint, and it isn't using a specific esprima version we need to change the hash every now and again.

### Screenshot

### Related Issue
