### PR TITLE
PSBEX-4: Add Layer Transparency Slider

### DIFF
--- a/src/common/layers/LayersDirective.js
+++ b/src/common/layers/LayersDirective.js
@@ -204,6 +204,14 @@
 
               return Object.assign({}, styleChoices, overrides);
             };
+
+            scope.initializeOpacity = function(layer) {
+              // Heatmap layers do not get a config object with a default opacity.
+              // Let's initialize it here so that everything else can work properly.
+              if (_.isNil(_.get(layer.get('metadata'), 'config.opacity'))) {
+                _.set(layer.get('metadata'), 'config.opacity', layer.getOpacity());
+              }
+            };
           }
         };
       }

--- a/src/common/layers/partials/layers.tpl.html
+++ b/src/common/layers/partials/layers.tpl.html
@@ -81,6 +81,12 @@
             </a>
           </div>
         </div>
+        <div class="container opacity-slider" ng-if="layer.get('metadata').config.group !== 'background'">
+          <input type="range" min="0" max="1" step=".01"
+            ng-init="initializeOpacity(layer)"
+            ng-model="layer.get('metadata').config.opacity"
+            ng-change="layer.setOpacity(layer.get('metadata').config.opacity)" />
+        </div>
           <div class="container" ng-show="hasStylePermissions(layer) && layer.get('metadata').showStylePanel">
           <label id="style-label" class="ellipsis" for="styleRow">
               {{ layer.get('metadata').defaultStyle.name }}.sld

--- a/src/common/layers/style/layers.less
+++ b/src/common/layers/style/layers.less
@@ -111,6 +111,18 @@
   }
 }
 
+.opacity-slider {
+  &.container {
+    display: flex;
+    justify-content: center;
+    padding: 10px 20px 0px 20px;
+  }
+
+  input {
+    flex-grow: 1;
+  }
+}
+
 .style-editor-item button,
 .style-editor-item .controls input {
   padding: 5px 5px;

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -1280,6 +1280,10 @@
           meta.layerOrder++;
         }
 
+        if (!_.isNil(meta.config.opacity)) {
+          layer.setOpacity(meta.config.opacity);
+        }
+
         var insertIndex = -1;
 
         for (var index = 0; index < mapLayers.length; index++) {


### PR DESCRIPTION
__Part of the "UN work" that Product requested to be merged__

## Issue Number
[PSBEX-4](https://issues.boundlessgeo.com:8443/browse/PSBEX-4)

## What does this PR do?
Add a slider for transparency in the layer info section of the left menu.
Does not appear for base layers.
Transparency setting is saved in the map configuration and is used on map load.

### Screenshot
![psbex4](https://user-images.githubusercontent.com/4530776/43338459-081eaaee-919c-11e8-923f-cacdf1d1e9d4.gif)

### Related Issue
[PSBEX-4](https://issues.boundlessgeo.com:8443/browse/PSBEX-4)