### PR TITLE
PSBEX-22: Set English as fallback language

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -93,6 +93,8 @@
   });
 
   module.config(function($translateProvider) {
-    $translateProvider.preferredLanguage('en');
+    $translateProvider
+      .fallbackLanguage('en')
+      .preferredLanguage('en');
   });
 }());


### PR DESCRIPTION
__Part of the "UN work" that Product requested to be merged__

## Issue Number
[PSBEX-22](https://issues.boundlessgeo.com:8443/browse/PSBEX-22)

## What does this PR do?
Set English as the fallback language to use when translations are missing for the user's language.

### Screenshot
_none_

### Related Issue
[PSBEX-22](https://issues.boundlessgeo.com:8443/browse/PSBEX-22)
