### PR TITLE
XYZ maps implementation

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -56,6 +56,10 @@ var SERVER_SERVICE_USE_PROXY = true;
         });
       }
 
+      // allows for a server id to return for an XYZ layer
+      if (id === 'xyz') {
+        server = {name: 'XYZ Source'};
+      }
       for (var index = 0; index < servers.length; index += 1) {
         if (servers[index].id === id) {
           server = servers[index];

--- a/src/common/layers/style/layers.less
+++ b/src/common/layers/style/layers.less
@@ -121,7 +121,7 @@
 }
 
 #layerpanel-group {
-  max-height: 700px;
+  max-height: 400px;
 }
 
 div.carousel-inner>.item>.item {

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -708,6 +708,28 @@
       var nameSplit = null;
       var url = null;
       var bbox;
+      // allow for a XYZ to be directly added to the map
+      if (minimalConfig.type === 'OpenLayers.Layer.XYZ' && minimalConfig.args[1].toString().startsWith('http')) {
+        console.log(minimalConfig);
+        url = minimalConfig.args[1].toString();
+        layer = new ol.layer.Tile({
+          metadata: {
+            serverId: 'xyz',
+            name: minimalConfig.name,
+            title: minimalConfig.name
+          },
+          visible: minimalConfig.visibility,
+          source: new ol.source.XYZ({
+            url: url,
+            attributions: [
+              new ol.Attribution({
+                html: minimalConfig.args[2].attribution
+              })
+            ]
+          })
+        });
+        return layer;
+      }
       if (!goog.isDefAndNotNull(fullConfig)) {
         //dialogService_.error(translate_.instant('map_layers'), translate_.instant('load_layer_failed',
         //    {'layer': minimalConfig.name}), [translate_.instant('btn_ok')], false);

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -709,8 +709,7 @@
       var url = null;
       var bbox;
       // allow for a XYZ to be directly added to the map
-      if (minimalConfig.type === 'OpenLayers.Layer.XYZ' && minimalConfig.args[1].toString().startsWith('http')) {
-        console.log(minimalConfig);
+      if (minimalConfig.type === 'OpenLayers.Layer.XYZ' && minimalConfig.args[1].toString().indexOf('http') == 0) {
         url = minimalConfig.args[1].toString();
         layer = new ol.layer.Tile({
           metadata: {


### PR DESCRIPTION
Added support for XYZ maps from the geonode config

Example:
```python
MAP_BASELAYERS = [{
    "source": {"ptype": "gxp_olsource"},
    "type": "OpenLayers.Layer",
    "args": ["No background"],
    "name": "background",
    "visibility": False,
    "fixed": True,
    "group":"background"
}, {
    "source": {"ptype": "gxp_olsource"},
    "type": "OpenLayers.Layer.XYZ",
    "args": [
        "Mapbox Streets",
        ["https://bcs.boundlessgeo.io/basemaps/mapbox/streets/{z}/{x}/{y}.png?apikey=add-api-key&version=0.1"],
        {
            'transitionEffect': 'resize',
            'attribution': 'Mapbox 2017'
        }
    ],
    "name": "Mapbox Streets",
    "visibility": True,
    "fixed": True,
    "group": "background"
}]
```
