### PR TITLE
Use Layer Metadata and Options When Editing

### DIFF
--- a/src/common/featuremanager/AttributeEditDirective.js
+++ b/src/common/featuremanager/AttributeEditDirective.js
@@ -16,9 +16,16 @@
               scope.isRemoving = false;
               var tempProperties = {};
               var attributeTypes = featureManagerService.getSelectedLayer().get('metadata').schema;
+              var exchangeMetadata = featureManagerService.getSelectedLayer().get('exchangeMetadata');
+
               if (goog.isDefAndNotNull(attributeTypes)) {
                 goog.array.forEach(properties, function(property, index, arr) {
                   var prop;
+                  if (!scope.isAttributeVisible(property[0])) {
+                    return;
+                  }
+                  var exchangeAttributes = _.find(exchangeMetadata.attributes, {attribute: property[0]});
+
                   if (goog.isDefAndNotNull(attributeTypes[property[0]]) &&
                       attributeTypes[property[0]]._type.search('gml:') === -1) {
                     prop = goog.object.clone(property);
@@ -33,6 +40,13 @@
                       ];
                     }
                     prop.nillable = attributeTypes[prop[0]]._nillable;
+
+                    if (exchangeAttributes) {
+                      prop.label = exchangeAttributes.attribute_label;
+                      prop.required = exchangeAttributes.required;
+                      prop.readOnly = exchangeAttributes.readonly;
+                    }
+
                     scope.validateField(prop, 1);
                     tempProperties[property[0]] = prop;
                   }

--- a/src/common/featuremanager/FeatureManagerService.js
+++ b/src/common/featuremanager/FeatureManagerService.js
@@ -392,6 +392,14 @@
               }
             }
           }
+
+          if (goog.isDefAndNotNull(selectedLayer_) && goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata')) &&
+              goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata').attributes)) {
+            props = _.sortBy(props, function(prop) {
+              return _.find(selectedLayer_.get('exchangeMetadata').attributes, { 'attribute': prop[0] }).display_order;
+            });
+          }
+
           selectedItemProperties_ = props;
           console.log('---- selectedItemProperties_: ', selectedItemProperties_);
 

--- a/src/common/featuremanager/partial/attributeedit.tpl.html
+++ b/src/common/featuremanager/partial/attributeedit.tpl.html
@@ -28,27 +28,27 @@
       </div>
 
       <div ng-if="!featureManagerService.isMediaPropertyName(prop[0])">
-        <label class="control-label custom-control-label">{{prop[0]}}</label>
+        <label class="control-label custom-control-label">{{prop.label !== '' ? prop.label : prop[0]}}</label>
         <div ng-switch on="prop.type">
-          <datetimepicker ng-switch-when="xsd:dateTime" date-object="prop[1]" default-date="inserting"></datetimepicker>
-          <datetimepicker ng-switch-when="xsd:date" date-object="prop[1]" default-date="inserting" time="false"></datetimepicker>
-          <datetimepicker ng-switch-when="xsd:time" date-object="prop[1]" default-date="inserting" date="false"></datetimepicker>
+          <datetimepicker editable="{{!prop.readOnly}}" ng-switch-when="xsd:dateTime" date-object="prop[1]" default-date="inserting"></datetimepicker>
+          <datetimepicker editable="{{!prop.readOnly}}" ng-switch-when="xsd:date" date-object="prop[1]" default-date="inserting" time="false"></datetimepicker>
+          <datetimepicker editable="{{!prop.readOnly}}" ng-switch-when="xsd:time" date-object="prop[1]" default-date="inserting" date="false"></datetimepicker>
           <div ng-switch-when="simpleType" ng-class="{'has-error': !prop.valid}">
-            <select ng-model="prop[1]" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in prop.enum" ng-change="validateField(prop, 1)" class="form-control">
+            <select ng-model="prop[1]" ng-readonly="prop.readOnly" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in prop.enum" ng-change="validateField(prop, 1)" class="form-control">
               <option></option>
             </select>
           </div>
           <div ng-switch-when="xsd:int" ng-class="{'has-error': !prop.valid}">
-            <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
+            <input ng-model="prop[1]" ng-readonly="prop.readOnly" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
           </div>
           <div ng-switch-when="xsd:integer" ng-class="{'has-error': !prop.valid}">
-            <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
+            <input ng-model="prop[1]" ng-readonly="prop.readOnly" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
           </div>
           <div ng-switch-when="xsd:double" ng-class="{'has-error': !prop.valid}">
-            <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
+            <input ng-model="prop[1]" ng-readonly="prop.readOnly" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
           </div>
           <div ng-switch-when="xsd:decimal" ng-class="{'has-error': !prop.valid}">
-            <input ng-model="prop[1]" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
+            <input ng-model="prop[1]" ng-readonly="prop.readOnly" type="text" class="form-control" ng-change="validateField(prop, 1)"/>
           </div>
           <div ng-switch-when="xsd:boolean" class="input-group"  ng-class="{'has-error': !prop.valid}">
             <div class="input-group-btn" ng-class="{'dropup': $last}">
@@ -57,17 +57,17 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a ng-click="selectValue(prop, null)">&nbsp;</a>
+                  <a ng-click="!prop.readOnly && selectValue(prop, null)">&nbsp;</a>
                 </li>
                 <li ng-repeat="enum in prop.enum">
-                  <a ng-click="selectValue(prop, $index)" translate="{{enum._value}}"></a>
+                  <a ng-click="!prop.readOnly && selectValue(prop, $index)" translate="{{enum._value}}"></a>
                 </li>
               </ul>
             </div>
             <input value="{{translate(prop[1])}}" type="text" class="form-control" disabled/>
           </div>
           <div ng-switch-default  ng-class="{'has-error': !prop.valid}">
-            <autotextarea ng-model="prop[1]" class="form-control custom-form-control auto-text-area" ng-change="validateField(prop, 1)"></autotextarea>
+            <autotextarea ng-readonly="prop.readOnly" ng-model="prop[1]" class="form-control custom-form-control auto-text-area" ng-change="validateField(prop, 1)"></autotextarea>
           </div>
         </div>
       </div>

--- a/src/common/featuremanager/partial/attributeedit.tpl.html
+++ b/src/common/featuremanager/partial/attributeedit.tpl.html
@@ -28,7 +28,7 @@
       </div>
 
       <div ng-if="!featureManagerService.isMediaPropertyName(prop[0])">
-        <label class="control-label custom-control-label">{{prop.label !== '' ? prop.label : prop[0]}}</label>
+        <label class="control-label custom-control-label">{{prop.label && prop.label !== '' ? prop.label : prop[0]}}</label>
         <div ng-switch on="prop.type">
           <datetimepicker editable="{{!prop.readOnly}}" ng-switch-when="xsd:dateTime" date-object="prop[1]" default-date="inserting"></datetimepicker>
           <datetimepicker editable="{{!prop.readOnly}}" ng-switch-when="xsd:date" date-object="prop[1]" default-date="inserting" time="false"></datetimepicker>

--- a/src/common/tableview/TableViewDirective.js
+++ b/src/common/tableview/TableViewDirective.js
@@ -178,6 +178,14 @@
               scope.currentPage = tableViewService.currentPage + 1;
               scope.totalPages = tableViewService.totalPages;
               scope.totalFeatures = tableViewService.totalFeatures;
+
+              _.forEach(scope.attributes, function(attribute) {
+                var exchangeAttributes = getExchangeMetadataAttribute(attribute.name);
+                if (exchangeAttributes.type && exchangeAttributes.options.length > 0) {
+                  scope.restrictions[attribute.name].type = 'simpleType';
+                  scope.restrictions[attribute.name].options = exchangeAttributes.options;
+                }
+              });
             };
 
             var clearSession = function() {

--- a/src/common/tableview/partial/tableview.tpl.html
+++ b/src/common/tableview/partial/tableview.tpl.html
@@ -76,6 +76,11 @@
                     <datetimepicker ng-if="tableviewform.$visible" id="table-datetime" date-object="row.feature.properties[attr.name]"
                                     default-date="false" seperate-time="false" date="false"></datetimepicker>
                 </div>
+                <div ng-switch-when="simpleType" ng-class="{'has-error': !prop.valid}">
+                    <select ng-model="row.feature.properties[attr.name]" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in prop.enum" class="form-control">
+                        <option></option>
+                    </select>
+                </div>
               <div ng-switch-default class="input-group">
                 <span ng-if="!tableviewform.$visible">{{getAttributeValue(attr.name, row.feature.properties[attr.name])}}</span>
                 <select ng-if="tableviewform.$visible" ng-model="row.feature.properties[attr.name]" ng-options="enum._value as (enum._label) ? enum._label : enum._value for enum in restrictions[attr.name].type" class="form-control" style="width:160px">


### PR DESCRIPTION
## Issue Number
[PSBEX-34](https://issues.boundlessgeo.com:8443/browse/PSBEX-34)
[PSBEX-117](https://issues.boundlessgeo.com:8443/browse/PSBEX-117)

## Related PR
_link GeoNode PR_

## What does this PR do?
* Metadata configured in Exchange's Edit Layer > Edit Metadata is used in MapLoom when editing a single feature.
* Metadata configured in Exchange's Edit Layer > Edit Metadata is used in MapLoom when editing features from the "table view".

Metadata used includes:
* Label
* Display Order
* Visible
* Required
* Enums (Options)
* Readonly

### Screenshots
Edit Attributes, without metadata changes
<img width="438" alt="edit-no_changes" src="https://user-images.githubusercontent.com/4530776/43481361-64d242dc-94cb-11e8-9a64-61dbaf355b69.png">

Edit Attributes, with metadata changes
<img width="444" alt="edit-changes" src="https://user-images.githubusercontent.com/4530776/43481375-6ca95c8e-94cb-11e8-8689-c4152a3a40b9.png">

Table View
<img width="1254" alt="table_view-editing" src="https://user-images.githubusercontent.com/4530776/43481421-864c0cc2-94cb-11e8-8274-f1486e392330.png">

Table View, editing
<img width="1250" alt="table_view" src="https://user-images.githubusercontent.com/4530776/43481395-756363c4-94cb-11e8-858f-984aa892e42e.png">

### Related Issue
[PSBEX-34](https://issues.boundlessgeo.com:8443/browse/PSBEX-34)
[PSBEX-117](https://issues.boundlessgeo.com:8443/browse/PSBEX-117)