### PR TITLE
ESRI metadata has capital T Title

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -934,7 +934,7 @@
               serverId: server.id,
               name: minimalConfig.name,
               bbox: bbox,
-              title: fullConfig.Title
+              title: fullConfig.Title || fullConfig.title
             },
             visible: minimalConfig.visibility,
             source: tilemapServiceSource
@@ -958,7 +958,7 @@
             serverId: server.id,
             name: minimalConfig.name,
             bbox: bbox,
-            title: fullConfig.Title
+            title: fullConfig.Title || fullConfig.title
           };
           var attribution = new ol.Attribution({
             html: 'Tiles &copy; <a href="' + server.url + '">ArcGIS</a>'

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -934,7 +934,7 @@
               serverId: server.id,
               name: minimalConfig.name,
               bbox: bbox,
-              title: fullConfig.title
+              title: fullConfig.Title
             },
             visible: minimalConfig.visibility,
             source: tilemapServiceSource


### PR DESCRIPTION
BEX-1039

ESRI remote layer names are loading differently in Maploom from the main search and within Maploom using the add layer dialog.
As a user I would expect no matter the option used to create a map or add a layer that the layer name should be consistent and the same.
STEPS
- Main search, click or add layers to a workspace to create a map
- Layer loads
or
- Maps, Create Map
- Add layer dialog
- Select and add layer
- Layer named different

https://github.com/boundlessgeo/MapLoom/blob/master/src/common/addlayers/ServerService.js#L586