### PR TITLE
Also check for SRID

### DIFF
--- a/src/common/addlayers/LayersService.js
+++ b/src/common/addlayers/LayersService.js
@@ -61,6 +61,12 @@
 
         if (layerConfig.CRS && layerConfig.extent) {
           mapService_.zoomToExtentForProjection(layerConfig.extent, ol.proj.get(layerConfig.CRS[0]));
+        }else if (goog.isDefAndNotNull(layerConfig.srid) && goog.isDefAndNotNull(layerConfig.bbox_bottom)) {
+          extent = [
+            layerConfig.bbox_left, layerConfig.bbox_bottom,
+            layerConfig.bbox_right, layerConfig.bbox_top
+          ];
+          mapService_.zoomToExtentForProjection(extent, ol.proj.get(layerConfig.srid));
         }
       }
     };


### PR DESCRIPTION
## Issue Number

BEX-930

User is seeing some bounding box issues with remote services in Maploom when a new map is created from search. The remote service is added to maploom but zooms to Antartica, if the user is able to click zoom to data without receiving a getcode error, the map redirects and zooms to the correct location.
