### PR TITLE
Prevents layers from being disabled.

### DIFF
--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -736,7 +736,11 @@
                   });
                 } else {
                   layer.add = true;
-                  layer.name = layer.typename;
+                  if (layer.typename.split(':').length === 2) {
+                    layer.name = layer.typename.split(':')[1];
+                  } else {
+                    layer.name = layer.typename;
+                  }
                   LayersService.addLayer(layer, server_to_use.id, server_to_use);
                 }
               });


### PR DESCRIPTION
## Issue Number
BEX-889

## What does this PR do?

User is seeing remote service layers showing up disabled when a map is saved with only remote services and then reloaded from Explore Maps. The user is able to successfully add the remote service layers and save the map but when the map is reloaded from Explore Maps, the layers show up disabled.
This issue is occurring when the Add Layer dialog in Maploom is used

STEPS:
- Create map
- Add Remote Services from Add Layer Dialog
- Save map
- Maps, Explore Maps
- Click on the saved map to open
- Layers show up disabled

### Screenshot
