### PR TITLE
Grab the crs that matches the maps crs

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -625,11 +625,14 @@ var SERVER_SERVICE_USE_PROXY = true;
         }
         if (hasConfig) {
           layerConfig = layersConfig[index];
+          var map_crs = configService_.configuration.map.projection;
           if (goog.isDefAndNotNull(layerConfig.CRS)) {
             for (var code in layerConfig.CRS) {
               if (layerConfig.CRS[code] !== 'CRS:84') {
-                layerConfig.CRS = [layerConfig.CRS[code]];
-                break;
+                if (layerConfig.CRS[code] === map_crs) {
+                  layerConfig.CRS = [layerConfig.CRS[code]];
+                  break;
+                }
               }
             }
           }


### PR DESCRIPTION
## Issue Number

BEX-1006

## What does this PR do?

Fixes the issue where the feature popup is not rendered in the correct location after creating new feature. While troubleshooting, I noticed that the error doesn't exist when the map crs is EPSG:4326 which led me to the line of code addressed in this PR which was grabbing the first crs from the list and happened to be EPSG:4326. Rather than taking that approach, the fix looks up the current maps crs in the list of supported crs's and if found, it returns it.

### Screenshot

<img width="749" alt="create a layer extent issue" src="https://user-images.githubusercontent.com/947403/45586058-c0522380-b8b5-11e8-98a8-7aa44e0d6042.png">

