### PR TITLE
BEX-497

### DIFF
--- a/src/common/diff/FeatureDiffService.js
+++ b/src/common/diff/FeatureDiffService.js
@@ -654,28 +654,31 @@
         properties[propertyIndex].editable = editable;
       }
     }
-    if (!_.isNil(service_.layer.get('exchangeMetadata')) &&
-        !_.isNil(service_.layer.get('exchangeMetadata').attributes) &&
-        !_.isEmpty(service_.layer.get('exchangeMetadata').attributes)) {
-      properties = _.chain(properties)
-          .sortBy(function(attr) {
-            return _.find(service_.layer.get('exchangeMetadata').attributes, { 'attribute': attr.attributename }).display_order;
-          })
-          .map(function(attr) {
-            var exchangeAttribute = _.find(service_.layer.get('exchangeMetadata').attributes, { 'attribute': attr.attributename });
-            if (!_.isNil(exchangeAttribute) && _.isArray(exchangeAttribute.options) && !_.isEmpty(exchangeAttribute.options)) {
-              attr.type = 'simpleType';
-              attr.enum = _.map(exchangeAttribute.options, function(option) {
-                return {
-                  _value: option.value,
-                  _label: option.value + ' - ' + option.label
-                };
-              });
-            }
-            return attr;
-          })
-          .value();
+    try {
+      if (!_.isNil(service_.layer.get('exchangeMetadata')) &&
+          !_.isNil(service_.layer.get('exchangeMetadata').attributes) &&
+          !_.isEmpty(service_.layer.get('exchangeMetadata').attributes)) {
+        properties = _.chain(properties)
+            .sortBy(function(attr) {
+              return _.find(service_.layer.get('exchangeMetadata').attributes, { 'attribute': attr.attributename }).display_order;
+            })
+            .map(function(attr) {
+              var exchangeAttribute = _.find(service_.layer.get('exchangeMetadata').attributes, { 'attribute': attr.attributename });
+              if (!_.isNil(exchangeAttribute) && _.isArray(exchangeAttribute.options) && !_.isEmpty(exchangeAttribute.options)) {
+                attr.type = 'simpleType';
+                attr.enum = _.map(exchangeAttribute.options, function(option) {
+                  return {
+                    _value: option.value,
+                    _label: option.value + ' - ' + option.label
+                  };
+                });
+              }
+              return attr;
+            })
+            .value();
+      }
     }
+    catch (err) {}
     return properties;
   }
 

--- a/src/common/featuremanager/AttributeEditDirective.js
+++ b/src/common/featuremanager/AttributeEditDirective.js
@@ -60,29 +60,32 @@
               }
 
               var selectedLayer = featureManagerService.getSelectedLayer();
-              if (goog.isDefAndNotNull(selectedLayer) && goog.isDefAndNotNull(selectedLayer.get('exchangeMetadata')) &&
-                  goog.isDefAndNotNull(selectedLayer.get('exchangeMetadata').attributes)) {
-                scope.properties = _.sortBy(scope.properties, function(prop) {
-                  return _.find(selectedLayer.get('exchangeMetadata').attributes, { 'attribute': prop[0] }).display_order;
-                });
-                _.chain(selectedLayer.get('exchangeMetadata').attributes)
-                    .filter(function(attribute) {
-                      return _.isArray(attribute.options) && !_.isEmpty(attribute.options);
-                    })
-                    .each(function(attribute) {
-                      var property = _.find(scope.properties, { 0: attribute.attribute });
-                      if (property) {
-                        property.type = 'simpleType';
-                        property.enum = _.map(attribute.options, function(option) {
-                          return {
-                            _value: option.value,
-                            _label: option.value + ' - ' + option.label
-                          };
-                        });
-                      }
-                    })
-                    .commit();
+              try {
+                if (goog.isDefAndNotNull(selectedLayer) && goog.isDefAndNotNull(selectedLayer.get('exchangeMetadata')) &&
+                    goog.isDefAndNotNull(selectedLayer.get('exchangeMetadata').attributes)) {
+                  scope.properties = _.sortBy(scope.properties, function(prop) {
+                    return _.find(selectedLayer.get('exchangeMetadata').attributes, { 'attribute': prop[0] }).display_order;
+                  });
+                  _.chain(selectedLayer.get('exchangeMetadata').attributes)
+                      .filter(function(attribute) {
+                        return _.isArray(attribute.options) && !_.isEmpty(attribute.options);
+                      })
+                      .each(function(attribute) {
+                        var property = _.find(scope.properties, { 0: attribute.attribute });
+                        if (property) {
+                          property.type = 'simpleType';
+                          property.enum = _.map(attribute.options, function(option) {
+                            return {
+                              _value: option.value,
+                              _label: option.value + ' - ' + option.label
+                            };
+                          });
+                        }
+                      })
+                      .commit();
+                }
               }
+              catch (err) {}
 
               if (geometry.type.toLowerCase() == 'point') {
                 if (projection === 'EPSG:4326') {

--- a/src/common/featuremanager/FeatureManagerService.js
+++ b/src/common/featuremanager/FeatureManagerService.js
@@ -393,12 +393,15 @@
             }
           }
 
-          if (goog.isDefAndNotNull(selectedLayer_) && goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata')) &&
-              goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata').attributes)) {
-            props = _.sortBy(props, function(prop) {
-              return _.find(selectedLayer_.get('exchangeMetadata').attributes, { 'attribute': prop[0] }).display_order;
-            });
+          try {
+            if (goog.isDefAndNotNull(selectedLayer_) && goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata')) &&
+                goog.isDefAndNotNull(selectedLayer_.get('exchangeMetadata').attributes)) {
+              props = _.sortBy(props, function(prop) {
+                return _.find(selectedLayer_.get('exchangeMetadata').attributes, { 'attribute': prop[0] }).display_order;
+              });
+            }
           }
+          catch (err) {}
 
           selectedItemProperties_ = props;
           console.log('---- selectedItemProperties_: ', selectedItemProperties_);

--- a/src/common/featuremanager/partial/featureinfobox.tpl.html
+++ b/src/common/featuremanager/partial/featureinfobox.tpl.html
@@ -57,7 +57,8 @@
                 tooltip="{{'set_spatial_filter' | translate}}" class="btn btn-sm btn-default glyphicon glyphicon-filter">
         </button>
         <button type="button" ng-if="!featureManagerService.getSelectedLayer().get('metadata').wmsOnly &&
-        !featureManagerService.getSelectedLayer().get('metadata').spatialFilterLayer" ng-click="showTable(featureManagerService.getSelectedLayer())" tooltip-append-to-body="true" tooltip-placement="top"
+        !featureManagerService.getSelectedLayer().get('metadata').spatialFilterLayer &&
+        !featureManagerService.getSelectedLayer().get('exchangeMetadata').remote" ng-click="showTable(featureManagerService.getSelectedLayer())" tooltip-append-to-body="true" tooltip-placement="top"
                 tooltip="{{'show_table' | translate}}" class="btn btn-sm btn-default glyphicon glyphicon-list">
             <div class="loom-loading" spinner-radius="16" spinner-hidden="!isLoadingTable(featureManagerService.getSelectedLayer())"></div>
         </button>

--- a/src/common/tableview/TableViewService.js
+++ b/src/common/tableview/TableViewService.js
@@ -56,6 +56,7 @@
     };
 
     this.showTable = function(layer, feature) {
+      console.log('show table', layer, feature);
       service_.rows = [];
       service_.attributeNameList = [];
       service_.restrictionList = {};
@@ -451,12 +452,15 @@
           return metadata.schema[prop.name].visible;
         });
         // Use the Exchange metadata display_order if it exists
-        if (!_.isNil(service_.selectedLayer) && !_.isNil(service_.selectedLayer.get('exchangeMetadata')) &&
-            !_.isNil(service_.selectedLayer.get('exchangeMetadata').attributes)) {
-          service_.attributeNameList = _.sortBy(service_.attributeNameList, function(prop) {
-            return _.find(service_.selectedLayer.get('exchangeMetadata').attributes, { 'attribute': prop.name }).display_order;
-          });
+        try {
+          if (!_.isNil(service_.selectedLayer) && !_.isNil(service_.selectedLayer.get('exchangeMetadata')) &&
+              !_.isNil(service_.selectedLayer.get('exchangeMetadata').attributes)) {
+            service_.attributeNameList = _.sortBy(service_.attributeNameList, function(prop) {
+              return _.find(service_.selectedLayer.get('exchangeMetadata').attributes, { 'attribute': prop.name }).display_order;
+            });
+          }
         }
+        catch (err) {}
         service_.totalFeatures = data.totalFeatures;
         service_.totalPages = Math.ceil(service_.totalFeatures / service_.resultsPerPage);
         getRestrictions();


### PR DESCRIPTION
remove table link for remote wms, add try block to prevent error when display_order doesnot exist

## Issue Number
BEX-497

## What does this PR do?
Removes the table link when clicking on a feature for a remote service as the remote service needs to be proxied for CORS and creating a table from a remote WMS can be unreliable.

Adds try block around all instances that try to sort by display_order as remote WMS layers don't have a display order to prevent client errors.

### Screenshot

### Related Issue
