### PR TITLE
MapLoom PKI functionality

### DIFF
--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -558,7 +558,12 @@ var SERVER_SERVICE_USE_PROXY = true;
      * Read the configuration for a server.
      */
     this.populateLayersConfigRest = function(server, force, deferredResponse) {
-      var meta_url = server.url + '?f=pjson';
+      var meta_url = server.url;
+      if (server.url.indexOf('?') === -1) {
+        meta_url = server.url + '?f=pjson';
+      } else {
+        meta_url = server.url.replace(/(.)\/$/, '$1') + '&f=pjson';
+      }
       var url = configService_.configuration.proxy + encodeURIComponent(meta_url);
 
       // convert the ESRI spatial reference to an EPSG code.

--- a/src/common/addlayers/ServerService.js
+++ b/src/common/addlayers/ServerService.js
@@ -707,7 +707,7 @@ var SERVER_SERVICE_USE_PROXY = true;
     var cleanTileUrl = function(tileUrl) {
       // this is definitely an absolute URL if it starts with http
       if (tileUrl.substring(0, 4).toLowerCase() == 'http') {
-        return trimUrl.substring(trimUrl.indexOf('//'));
+        return tileUrl.substring(tileUrl.indexOf('//'));
       }
 
       // double-slash is short hand for schemaless http,

--- a/src/common/addlayers/UnifiedSearchDirective.js
+++ b/src/common/addlayers/UnifiedSearchDirective.js
@@ -528,7 +528,9 @@
               // minimally, the number of layers should be limited to 100
               //   leaving out limit will result in 0 layers returned from the service.
               var params = {
-                limit: 100
+                limit: 100,
+                type: 'layer',
+                get_proxy: true
               };
 
               // add the search parameters to the params object.
@@ -722,7 +724,8 @@
                     ptype: layer_def.ptype,
                     isVirtualService: false,
                     remote: true,
-                    name: server_name
+                    name: server_name,
+                    use_proxy: layer.use_proxy
                   }).then(function(server) {
                     layer.add = true;
                     // pick the "best of", different version of the code will

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -126,6 +126,19 @@
       if (goog.isDefAndNotNull($window.config)) {
         goog.object.extend(this.configuration, $window.config, {});
       }
+      
+      // proxy basemap if config value proxyBaseMap is true
+      // this is specific to the OSM basemap because it is constructed here
+      // and may not be overriden by a passed in MapLayer from GeoNode
+      for (var source in this.configuration.sources) {
+        // the constructed default baselayer is just an OSM source
+        // with only one kvp - ptype: gxp_osmsource
+        if (Object.keys(this.configuration.sources[source].length === 1)) {
+          if (this.configuration.sources[source]['ptype'] == 'gxp_osmsource') {
+            this.configuration.sources[source]['use_proxy'] = this.configuration.proxyBaseMap;
+          }
+        }
+      }
 
       this.username = this.configuration.username;
       this.currentLanguage = this.configuration.currentLanguage;

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -133,7 +133,7 @@
       for (var source in this.configuration.sources) {
         // the constructed default baselayer is just an OSM source
         // with only one kvp - ptype: gxp_osmsource
-        if (Object.keys(this.configuration.sources[source].length === 1)) {
+        if (Object.keys(this.configuration.sources[source]).length === 1) {
           if (this.configuration.sources[source]['ptype'] == 'gxp_osmsource') {
             this.configuration.sources[source]['use_proxy'] = this.configuration.proxyBaseMap;
           }

--- a/src/common/configuration/ConfigService.js
+++ b/src/common/configuration/ConfigService.js
@@ -126,7 +126,7 @@
       if (goog.isDefAndNotNull($window.config)) {
         goog.object.extend(this.configuration, $window.config, {});
       }
-      
+
       // proxy basemap if config value proxyBaseMap is true
       // this is specific to the OSM basemap because it is constructed here
       // and may not be overriden by a passed in MapLayer from GeoNode

--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -4,7 +4,7 @@
   var legendOpen = false;
 
   module.directive('loomLegend',
-      function($rootScope, mapService, serverService) {
+      function($rootScope, mapService, serverService, configService) {
         return {
           restrict: 'C',
           replace: true,
@@ -114,7 +114,23 @@
               } else {
                 domain = server.url;
               }
-
+              // Proxy the domain if appropriate
+              var getUseProxyParam = function(server) {
+                return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
+              };
+              // proxy a url if the souce parameters indicate to do so
+              var useProxyUrlParam = function(use_proxy, url) {
+                if (goog.isDefAndNotNull(use_proxy) && use_proxy === true) {
+                  url = decodeURIComponent(url);
+                  if (url.indexOf(configService.configuration.proxy) < 0) {
+                    url = configService.configuration.proxy + encodeURIComponent(url);
+                  } else {
+                    url = encodeURIComponent(url);
+                  }
+                }
+                return url;
+              };
+              domain = useProxyUrlParam(getUseProxyParam(server), domain);
               var params = {
                 request: 'GetLegendGraphic',
                 format: 'image/png',

--- a/src/common/legend/LegendDirective.js
+++ b/src/common/legend/LegendDirective.js
@@ -114,23 +114,7 @@
               } else {
                 domain = server.url;
               }
-              // Proxy the domain if appropriate
-              var getUseProxyParam = function(server) {
-                return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
-              };
-              // proxy a url if the souce parameters indicate to do so
-              var useProxyUrlParam = function(use_proxy, url) {
-                if (goog.isDefAndNotNull(use_proxy) && use_proxy === true) {
-                  url = decodeURIComponent(url);
-                  if (url.indexOf(configService.configuration.proxy) < 0) {
-                    url = configService.configuration.proxy + encodeURIComponent(url);
-                  } else {
-                    url = encodeURIComponent(url);
-                  }
-                }
-                return url;
-              };
-              domain = useProxyUrlParam(getUseProxyParam(server), domain);
+              domain = useProxyUrlParam(getUseProxyParam(server), domain, configService);
               var params = {
                 request: 'GetLegendGraphic',
                 format: 'image/png',

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -987,7 +987,7 @@
           var tilemapServiceSource = new ol.source.TileArcGISRest({
             url: rest_url,
             params: {
-                'LAYERS': 'show:' + fullConfig.id
+              'LAYERS': 'show:' + fullConfig.id
             }
           });
 
@@ -1094,7 +1094,7 @@
           var jsontile_source = server.layersConfig[0].TileJSONSource;
 
           if (goog.isDefAndNotNull(jsontile_source)) {
-          // TODO: Do we want to override the url in fullConfig.sourceParams?
+            // TODO: Do we want to override the url in fullConfig.sourceParams?
             layer = new ol.layer.Tile({
               metadata: {
                 serverId: server.id,

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -840,6 +840,65 @@
             url: settings.OsmLocalUrl
           };
           var osmSource = (settings.OsmLocalUrl !== 'default') ? osmLocal : '';
+          var osmService = new ol.source.OSM(osmSource);
+          // The source will only have the one url in the first index
+          var osmUrl = useProxyUrlParam(getUseProxyParam(server), osmService.getUrls()[0]);
+          // OSM source doesn't want the url encoded
+          // OSM requires special encoding due to variable url
+          var encodeOSMUrl = function(osmUrl) {
+            // OSM source doesn't want the url encoded, make sure it is decoded
+            osmUrl = decodeURIComponent(osmUrl);
+            // Error check: don't encode osmUrl if it's not proxied
+            if (osmUrl.indexOf(configService_.configuration.proxy) < 0) {
+              return osmUrl;
+            }
+            // Must remove proxy from the url and add it back unencoded at the end
+            osmUrl = osmUrl.replace(configService_.configuration.proxy, '');
+
+            // Separate out parts that cannot be encoded, and only encode what is necessary
+            // osmUrl is regex with the following pattern:
+            // https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}
+            // parse out all {}, and only encoed non-bracket pieces
+            var openBracketIndex, closedBracketIndex, encodedOSMUrl = '';
+            while (osmUrl.indexOf('{') > -1) {
+              openBracketIndex = osmUrl.indexOf('{');
+              closedBracketIndex = osmUrl.indexOf('}');
+              // if the closed bracket comes before the open bracket, something has gone wrong
+              if (closedBracketIndex > openBracketIndex) {
+                // encode up to the open bracket
+                encodedOSMUrl += encodeURIComponent(osmUrl.substring(0, openBracketIndex));
+                // don't encode what's in the brackets
+                encodedOSMUrl += osmUrl.substring(openBracketIndex, closedBracketIndex + 1);
+                osmUrl = osmUrl.substring(closedBracketIndex + 1);
+              } else {
+                // TODO: what do we do if this happens?
+                // for now just skipping to next
+                osmUrl = osmUrl.substring(closedBracketIndex + 1);
+                // alert the user something went wrong
+                console.log('WARNING: A closing bracket } preceded an opening bracket { in url: ' + osmUrl);
+                // prevent infinite loop potential with dangling open bracket
+                if (osmUrl.indexOf('}') == -1 && osmUrl.indexOf('{') > -1) {
+                  osmUrl = osmUrl.substring(openBracketIndex + 1);
+                }
+              }
+            }
+            // TODO: What to do if there's dangling closed bracket?
+            if (osmUrl.indexOf('}') > -1) {
+              // alert the user something went wrong
+              console.log('WARNING: A dangling closed bracket } was in url: ' + osmUrl);
+            }
+            // encode anything remaining
+            encodedOSMUrl += encodeURIComponent(osmUrl);
+            return configService_.configuration.proxy + encodedOSMUrl;
+          };
+          // Only encode the OSM url if it's being proxied
+          var encodedOsmUrl;
+          if (osmUrl.indexOf(configService_.configuration.proxy) > -1) {
+            encodedOsmUrl = encodeOSMUrl(osmUrl);
+          } else {
+            encodedOsmUrl = osmUrl;
+          }
+          osmService.setUrl(encodedOsmUrl);
           layer = new ol.layer.Tile({
             metadata: {
               serverId: server.id,
@@ -847,7 +906,7 @@
               title: fullConfig.Title
             },
             visible: minimalConfig.visibility,
-            source: new ol.source.OSM(osmSource)
+            source: osmService
           });
         } else if (server.ptype === 'gxp_bingsource') {
 

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -962,7 +962,10 @@
           // This arc service does not support tiled maps, so this will
           // use the arc image service instead...
           var tilemapServiceSource = new ol.source.TileArcGISRest({
-            url: rest_url
+            url: rest_url,
+            params: {
+                'LAYERS': 'show:' + fullConfig.id
+            }
           });
 
           // patch the web mercator projection.

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -667,18 +667,6 @@
     };
 
     this.createLayerFull = function(minimalConfig, fullConfig, server, opt_layerOrder) {
-      // proxy a url if the souce parameters indicate to do so
-      var useProxyUrlParam = function(use_proxy, url) {
-        if (goog.isDefAndNotNull(use_proxy) && use_proxy === true) {
-          url = decodeURIComponent(url);
-          if (url.indexOf(configService_.configuration.proxy) < 0) {
-            url = configService_.configuration.proxy + encodeURIComponent(url);
-          } else {
-            url = encodeURIComponent(url);
-          }
-        }
-        return url;
-      };
       // fixes the projection and utilizes the proxy url if appropriate for the service
       var fixRequestUrl = function(service, use_proxy) {
         // WARNING! this is a monkey-patch for the ancient verison
@@ -696,13 +684,10 @@
           }
 
           var url = this._getRequestUrl_(tileCoord, tileSize, tileExtent, pixelRatio, proj, params);
-          return useProxyUrlParam(use_proxy, url);
+          return useProxyUrlParam(use_proxy, url, configService_);
         };
 
         return service;
-      };
-      var getUseProxyParam = function(server) {
-        return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
       };
       // download missing projection projection if we don't have it
       if (goog.isDefAndNotNull(fullConfig)) {
@@ -785,7 +770,7 @@
       } else {
         if (fullConfig.type && fullConfig.type == 'mapproxy_tms') {
           var src = new ol.source.XYZ({
-            url: useProxyUrlParam(getUseProxyParam(server), fullConfig.detail_url)
+            url: useProxyUrlParam(getUseProxyParam(server), fullConfig.detail_url, configService_)
           });
 
           // do not try to offer a GetFeatureInfo call if there
@@ -850,7 +835,7 @@
           layer = new ol.layer.Tile({
             metadata: {
               name: minimalConfig.name,
-              url: goog.isDefAndNotNull(mapproxyMostSpecificUrl) ? useProxyUrlParam(getUseProxyParam(server), mapproxyMostSpecificUrl) : undefined,
+              url: goog.isDefAndNotNull(mapproxyMostSpecificUrl) ? useProxyUrlParam(getUseProxyParam(server), mapproxyMostSpecificUrl, configService_) : undefined,
               title: fullConfig.title,
               extent: fullConfig['extent'],
               abstract: fullConfig.abstract,
@@ -879,7 +864,7 @@
           var osmSource = (settings.OsmLocalUrl !== 'default') ? osmLocal : '';
           var osmService = new ol.source.OSM(osmSource);
           // The source will only have the one url in the first index
-          var osmUrl = useProxyUrlParam(getUseProxyParam(server), osmService.getUrls()[0]);
+          var osmUrl = useProxyUrlParam(getUseProxyParam(server), osmService.getUrls()[0], configService_);
           // OSM source doesn't want the url encoded
           // OSM requires special encoding due to variable url
           var encodeOSMUrl = function(osmUrl) {
@@ -973,7 +958,7 @@
 
           var parms = {
             //url: 'http://api.tiles.mapbox.com/v3/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ',
-             url: useProxyUrlParam(getUseProxyParam(server), '//api.tiles.mapbox.com/v4/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ'),
+            url: useProxyUrlParam(getUseProxyParam(server), '//api.tiles.mapbox.com/v4/mapbox.' + fullConfig.sourceParams.layer + '.json?access_token=pk.eyJ1IjoiYmVja2VyciIsImEiOiJjaWtzcHVyeTYwMDA3dWdsenB5aHUxMzl1In0.1FVjOTdhoXGXtnfApX8wVQ', configService_),
             crossOrigin: true
           };
           var mbsource = new ol.source.TileJSON(parms);
@@ -1064,7 +1049,7 @@
           };
           // TODO: Should this portion be proxied?
           var attribution = new ol.Attribution({
-            html: 'Tiles &copy; <a href="' + useProxyUrlParam(getUseProxyParam(server), server.url) + '">ArcGIS</a>'
+            html: 'Tiles &copy; <a href="' + useProxyUrlParam(getUseProxyParam(server), server.url, configService_) + '">ArcGIS</a>'
           });
 
           // ensure the trailing slash is set.
@@ -1072,7 +1057,7 @@
           if (url.substring(url.length - 1) !== '/') {
             url += '/';
           }
-          var serviceUrl = useProxyUrlParam(getUseProxyParam(server), url) + 'tile/{z}/{y}/{x}';
+          var serviceUrl = useProxyUrlParam(getUseProxyParam(server), url, configService_) + 'tile/{z}/{y}/{x}';
           var arcrestServiceSource = null;
           if (server.proj === 'EPSG:4326') {
             var projection = ol.proj.get('EPSG:4326');
@@ -1222,7 +1207,7 @@
             metadata: {
               serverId: server.id,
               name: minimalConfig.name,
-              url: goog.isDefAndNotNull(wmscsourceMostSpecificUrl) ? useProxyUrlParam(getUseProxyParam(server), wmscsourceMostSpecificUrl) : undefined,
+              url: goog.isDefAndNotNull(wmscsourceMostSpecificUrl) ? useProxyUrlParam(getUseProxyParam(server), wmscsourceMostSpecificUrl, configService_) : undefined,
               title: fullConfig.Title || fullConfig.title,
               abstract: fullConfig.Abstract || fullConfig.abstract,
               keywords: fullConfig.KeywordList,
@@ -1335,7 +1320,7 @@
             metadata: {
               serverId: server.id,
               name: minimalConfig.name,
-              url: goog.isDefAndNotNull(url) ? useProxyUrlParam(getUseProxyParam(server), url) : undefined,
+              url: goog.isDefAndNotNull(url) ? useProxyUrlParam(getUseProxyParam(server), url, configService_) : undefined,
               title: fullConfig.Title,
               abstract: fullConfig.Abstract,
               keywords: fullConfig.KeywordList,

--- a/src/common/utils/Globals.js
+++ b/src/common/utils/Globals.js
@@ -315,3 +315,20 @@ var escapeXml = function(str) {
   }
   return str;
 };
+
+// Proxy the domain if appropriate
+var getUseProxyParam = function(server) {
+  return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
+};
+// proxy a url if the source parameters indicate to do so
+var useProxyUrlParam = function(use_proxy, url, configService) {
+  if (goog.isDefAndNotNull(use_proxy) && goog.isDefAndNotNull(configService) && use_proxy === true) {
+    url = decodeURIComponent(url);
+    if (url.indexOf(configService.configuration.proxy) < 0) {
+      url = configService.configuration.proxy + encodeURIComponent(url);
+    } else {
+      url = encodeURIComponent(url);
+    }
+  }
+  return url;
+};

--- a/src/index.html
+++ b/src/index.html
@@ -83,6 +83,9 @@
         return '//nominatim.openstreetmap.org';
       }
     };
+    var getBaseMapProxy = function(){
+      return "{{ PROXY_BASEMAP }}".toLowerCase() === "true";
+    };
 
     config =  {
         authStatus: {% if user.is_authenticated %} 200{% else %} 401{% endif %},
@@ -90,7 +93,7 @@
         currentLanguage: "{{language|default:'en'}}",
         userprofilename: {% if user.is_authenticated %} "{{ user.get_full_name }}" {% else %} undefined {% endif %},
         userprofileemail: {% if user.is_authenticated %} "{{ user.email }}" {% else %} undefined {% endif %},
-        proxy: "/proxy/?url=",
+        proxy: "{{ PROXY_URL }}" !== '' ? "{{ PROXY_URL }}" : "/proxy/?url=",
         searchUrl: getSearchUrl(),
         printService: trimUrl("{{GEOSERVER_BASE_URL}}pdf")+'/',
         /* The URL to a REST map configuration service.  This service
@@ -122,7 +125,8 @@
         nominatimSearchEnabled: nominatimSearchEnabled(),
         unifiedLayerDialog: unifiedDialogEnabled(),
         previewLayerConf: {{ MAP_PREVIEW_LAYER|safe }},
-        geoquerySearchEnabled: geoquerySearchEnabled()
+        geoquerySearchEnabled: geoquerySearchEnabled(),
+        proxyBaseMap: getBaseMapProxy()
     };
     goog.object.extend( config, {{ config|safe }});
     // clean up any of the sources URLs


### PR DESCRIPTION
New new version of: https://github.com/boundlessgeo/MapLoom/pull/164
All content is the same, but removing extraneous commits and conflicting content with master. 

## Issue Number
[PSBEX-192](https://issues.boundlessgeo.com:8443/browse/PSBEX-192)
[BEX-1058](https://issues.boundlessgeo.com:8443/browse/BEX-1058)

## What does this PR do?
Gets pki related MapLoom code, as well as some other fixes, merged back into master. Relates with many other changes in various submodules and Exchange. See the main Exchange PR here: https://github.com/boundlessgeo/exchange/pull/5

**Please test before merging.** The changes here should be "safe", in that MapLoom should work fine even if the commits from other components are not present, although PKI will not be functional.

### Change Summary
**Globals.js**
[L319](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-ece84220683d809c622957113ddcfde7R319): defines new functions for pki proxy handling in MapLoom: `getProxyUrlParam` and `useProxyUrlParam`

**ServerService.js**
[L561](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-6938e64f5577eb4f940a88095fca7874R561): fix query to recognize if there are already other query elements present
[L710](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-6938e64f5577eb4f940a88095fca7874R710): fixes a typo

**UnifiedSearchDirective.js**
[L531](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-bf51fd952b13e52184d58caa03a08502R531): additional parameters added
[L727](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-bf51fd952b13e52184d58caa03a08502R727): adds `use_proxy` param

**ConfigService.js**
[L130](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-cc5c100b059ada2bfd27e3977a61a262R130): allows us to proxy the OSM basemap

**LegendDirective.js**
[L117](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-e93fde9de98e9ae5d7c5485a12653f02R117): uses a proxy on the domain if appropriate & available

**index.html**
[L86](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-e249faefed5757034596c5096d33dab6R86): defines function to read `PROXY_BASEMAP` scope variable
[L96](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-e249faefed5757034596c5096d33dab6R96): reads `PROXY_URL` scope variable for a custom defined proxy, if it exists
[L129](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-e249faefed5757034596c5096d33dab6R129): defines `proxyBaseMap` config attribute

**MapService.js**
[L670](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R670): pulls out 'monkey patch' code and writes it as `fixRequestUrl` function, utilizing new `useProxyUrlParam` function
[L687](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R687),[773](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R773),[867](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R867),[961](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R961),[1052](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1052),[1060](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1060),[1210](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1210),[1323](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1323): uses new proxy functions to proxy connection to url, if appropriate
[L870](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R870): adds `encodeOSMurl` function which does some processing to allow us to uri encode a proxied OSM url, then uses it if we want to proxy the OSM url
[L989](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R989): fixes bug where ArcREST service wasn't being used to grab sources properly; grabs the correct source based on id now
[L1017](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1017): uses extracted, proxy friendly 'monkey patch' function created above, `fixRequestUrl`
[L1162](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1162): correctly handles bbox & proj
[L1182](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1182): adds else case if `server.version` is undefined
[L1201](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1201): uses `fixRequestUrl` with or without proxy
[L1212](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1212), [L1218](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1218), [L1222](https://github.com/boundlessgeo/MapLoom/pull/207/files#diff-fadffcc49475c46bdab044448bf65a82R1222) : adds backup `||` in case of different config variable names (different Exchange/GeoNode versions)

### Smoke Testing
With all PKI updates merged, we can run through the following actions to "smoke test" MapLoom functionality:

1. Create Map
    a. Basemap should load in MapLoom
    b. All buttons in the UI should function
2. Load layer from layers search
    a. Layer data should load features in MapLoom properly
    b. A legend should load in MapLoom, unless it is ArcREST
3. Edit a local layer
    a. Move a feature on the map
    b. Change an attribute of the feature
    c. Add a feature to the map
    d. Edit style
    e. Edit attributes of features in table
4. Add a layer to the map
    a. Clicking the add layer button should properly spawn modal
    b. Search results should be identical to layers search, including filters
    c. Adding layers should result in the layers loading features and legends in MapLoom properly
    d. Saving the map should persist all added layers
5. **[CORE CHANGE]** 2 and 4 should work the same for PKI protected layers as well
6. Unit tests should all pass
    a. grunt karmaconfig
    b. grunt test

### Screenshot
N/A

### Related Issue
[PSBEX-192](https://issues.boundlessgeo.com:8443/browse/PSBEX-192)
[PSBEX-193](https://issues.boundlessgeo.com:8443/browse/PSBEX-193)
[PSBEX-196](https://issues.boundlessgeo.com:8443/browse/PSBEX-196)
[BEX-1058](https://issues.boundlessgeo.com:8443/browse/BEX-1058)

See the main Exchange PR for the adjacent changes needed for full PKI functionality: https://github.com/boundlessgeo/exchange/pull/5

**CURRENT ISSUES**:
- Other submodules and Exchange need their PR's updated and linked.
- Layers added to the map via MapLoom (4) do not proxy correctly.