### PR TITLE
Remove save button for unauthorized users

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -458,5 +458,14 @@
 <% if (!(typeof django === 'undefined') && (django)) { %>
 {% endverbatim %}
 <% } %>
+<script>
+  // hide save map button if user is not a content creator
+  if ('{{ perms.maps.add_map }}' != 'True') {
+      // staff and superusers should be able to regardless
+      if ('{{ user.is_staff }}' != 'True' && '{{ user.is_superuser }}' != 'True') {
+          $('#saveButton').css('visibility', 'hidden');
+      }
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Issue Number
[BEX-1007](https://issues.boundlessgeo.com:8443/browse/BEX-1007)

## What does this PR do?
Removes the "Save Map" button when the user lacks permissions for adding a map.

### Screenshot

### Related Issue
[BEX-1007](https://issues.boundlessgeo.com:8443/browse/BEX-1007)
